### PR TITLE
alternative norm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "1.4.0"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 

--- a/test/ensemblegpuarray_inputtypes.jl
+++ b/test/ensemblegpuarray_inputtypes.jl
@@ -15,7 +15,7 @@ p = (10.0f0,28.0f0,8/3f0)
 prob = ODEProblem(lorenz,u0,tspan,p)
 prob_func = (prob,i,repeat) -> remake(prob,p=rand(Float32,3).*p)
 monteprob = EnsembleProblem(prob, prob_func = prob_func)
-#@time sol = solve(monteprob,Tsit5(),EnsembleGPUArray(),trajectories=10_000,saveat=1.0f0)
+@time sol = solve(monteprob,Tsit5(),EnsembleGPUArray(),trajectories=10_000,saveat=1.0f0)
 
 u0 = [1f0u"m";0u"m";0u"m"]
 tspan = (0.0f0u"s",100.0f0u"s")


### PR DESCRIPTION
```julia
using OrdinaryDiffEq, DiffEqGPU, ForwardDiff, Test, Unitful

function lorenz(du,u,p,t)
 @inbounds begin
     du[1] = p[1]*(u[2]-u[1])
     du[2] = u[1]*(p[2]-u[3]) - u[2]
     du[3] = u[1]*u[2] - p[3]*u[3]
 end
 nothing
end

u0 = [ForwardDiff.Dual(1f0,(1.0,0.0,0.0));ForwardDiff.Dual(0f0,(0.0,1.0,0.0));ForwardDiff.Dual(0f0,(0.0,0.0,1.0))]
tspan = (0.0f0,100.0f0)
p = (10.0f0,28.0f0,8/3f0)
prob = ODEProblem(lorenz,u0,tspan,p)
prob_func = (prob,i,repeat) -> remake(prob,p=rand(Float32,3).*p)
monteprob = EnsembleProblem(prob, prob_func = prob_func)

@inline ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual},::Any) = sqrt(sum(DiffEqBase.UNITLESS_ABS2∘DiffEqBase.value,u) / length(u))
@inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual,::Any) = abs(DiffEqBase.value(u))

@time sol = solve(monteprob,Tsit5(),EnsembleGPUArray(),trajectories=10_000,saveat=1.0f0,internalnorm=ODE_DEFAULT_NORM)
```

That fixed it. So the regression seems to be due to https://github.com/SciML/DiffEqBase.jl/commit/68daccd1b23563568699049488e9ba708efb96d8#diff-54090e4bd9da3cc6b0fbb839b246aeb3