### PR TITLE
fix continuous callbacks

### DIFF
--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -32,8 +32,9 @@ end
 end
 
 @kernel function continuous_affect!_kernel(affect!,event_idx,u,t,p)
-    i = @index(Global, Linear)
-    @views @inbounds affect!(FakeIntegrator(u[:,i],t,p[:,i]))
+    for i in event_idx
+        @views @inbounds affect!(FakeIntegrator(u[:,i],t,p[:,i]))
+    end
 end
 
 maxthreads(::CPU) = 1024


### PR DESCRIPTION
Before, this was:

```julia
function continuous_affect!_kernel(affect!,event_idx,u,t,p)
    @loop for i in ((event_idx,); (blockIdx().x-1) * blockDim().x + threadIdx().x)
        @views @inbounds affect!(FakeIntegrator(u[:,i],t,p[:,i]))
        nothing
    end
    nothing
end
```

@vchuravy could I get a quick check to see if this makes sense? This a kind of weird case where we really just want to launch a kernel mostly to hit the same abstraction: event_idx is even an integer most of the time, but we want to run this function on the GPU just because the values are already on the GPU.