### PR TITLE
Enhancement and Fixes in GPU Tsit5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
+*.jl.*.mem
 .DS_Store
 /Manifest.toml
 /dev/

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -308,7 +308,8 @@ function batch_solve(ensembleprob, alg, ensemblealg::EnsembleArrayAlgorithm, I, 
             ensembleprob.prob_func(ensembleprob.prob, i, 1)
         end
     end
-    @assert all(Base.Fix2((prob1,prob2) -> isequal(prob1.tspan,prob2.tspan), probs[1]), probs)
+    @assert all(Base.Fix2((prob1, prob2) -> isequal(prob1.tspan, prob2.tspan), probs[1]),
+                probs)
     @assert !isempty(I)
     #@assert all(p->p.f === probs[1].f,probs)
 

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -186,7 +186,8 @@ end
 function SciMLBase.__solve(ensembleprob::SciMLBase.AbstractEnsembleProblem,
                            alg::Union{SciMLBase.DEAlgorithm, Nothing,
                                       DiffEqGPU.GPUODEAlgorithm},
-                           ensemblealg::Union{EnsembleArrayAlgorithm, EnsembleKernelAlgorithm};
+                           ensemblealg::Union{EnsembleArrayAlgorithm,
+                                              EnsembleKernelAlgorithm};
                            trajectories, batch_size = trajectories,
                            unstable_check = (dt, u, p, t) -> false, adaptive = false,
                            kwargs...)
@@ -298,7 +299,9 @@ function diffeqgpunorm(u::AbstractArray{<:ForwardDiff.Dual}, t)
 end
 diffeqgpunorm(u::ForwardDiff.Dual, t) = abs(ForwardDiff.value(u))
 
-function batch_solve(ensembleprob, alg, ensemblealg::Union{EnsembleArrayAlgorithm, EnsembleKernelAlgorithm}, I, adaptive;
+function batch_solve(ensembleprob, alg,
+                     ensemblealg::Union{EnsembleArrayAlgorithm, EnsembleKernelAlgorithm}, I,
+                     adaptive;
                      kwargs...)
     if ensembleprob.safetycopy
         probs = map(I) do i
@@ -315,10 +318,6 @@ function batch_solve(ensembleprob, alg, ensemblealg::Union{EnsembleArrayAlgorith
     #@assert all(p->p.f === probs[1].f,probs)
 
     if ensemblealg isa EnsembleGPUKernel
-        # @time ps = CuArray(map(I) do i
-        #         probs[i].p
-        # end)
-        # ps = CuArray([SVector{length(probs[i].p)}(probs[i].p) for i in 1:length(I)])
         if typeof(alg) <: GPUTsit5
             #Adaptive version only works with saveat
             if adaptive

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -171,7 +171,7 @@ function EnsembleGPUArray()
 end
 
 function EnsembleGPUAutonomous()
-    EnsembleGPUAutonomous(0.2)
+    EnsembleGPUAutonomous(0.0)
 end
 
 function ChainRulesCore.rrule(::Type{<:EnsembleGPUArray})
@@ -320,10 +320,10 @@ function batch_solve(ensembleprob, alg, ensemblealg::EnsembleArrayAlgorithm, I, 
         if typeof(alg) <: GPUTsit5
             #Adaptive version only works with saveat
             if adaptive
-                ts, us = vectorized_asolve(ensembleprob.prob, ps, GPUSimpleATsit5();
+                ts, us = vectorized_asolve(cu(probs), ensembleprob.prob, GPUSimpleATsit5();
                                            kwargs...)
             else
-                ts, us = vectorized_solve(cu(probs),ensembleprob.prob, GPUSimpleTsit5();
+                ts, us = vectorized_solve(cu(probs), ensembleprob.prob, GPUSimpleTsit5();
                                           kwargs...)
             end
             solus = Array(us)

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -172,7 +172,7 @@ function EnsembleGPUArray()
 end
 
 function EnsembleGPUKernel()
-    EnsembleGPUKernel(0.0)
+    EnsembleGPUKernel(0.2)
 end
 
 function ChainRulesCore.rrule(::Type{<:EnsembleGPUArray})
@@ -327,16 +327,17 @@ function batch_solve(ensembleprob, alg,
                 ts, us = vectorized_solve(cu(probs), ensembleprob.prob, GPUSimpleTsit5();
                                           kwargs...)
             end
-            solus = Array(us)
-            solts = Array(ts)
-            [@views ensembleprob.output_func(SciMLBase.build_solution(probs[i], alg,
-                                                                      solts[:, i],
-                                                                      solus[:, i],
-                                                                      k = nothing,
-                                                                      destats = nothing,
-                                                                      calculate_error = false),
-                                             i)[1]
-             for i in eachindex(probs)]
+            []
+            # solus = Array(us)
+            # solts = Array(ts)
+            # [@views ensembleprob.output_func(SciMLBase.build_solution(probs[i], alg,
+            #                                                           solts[:, i],
+            #                                                           solus[:, i],
+            #                                                           k = nothing,
+            #                                                           destats = nothing,
+            #                                                           calculate_error = false),
+            #                                  i)[1]
+            #  for i in eachindex(probs)]
 
         else
             error("We don't have solvers implemented for this algorithm yet")

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -312,11 +312,6 @@ function batch_solve(ensembleprob, alg, ensemblealg::EnsembleArrayAlgorithm, I, 
     @assert !isempty(I)
     #@assert all(p->p.f === probs[1].f,probs)
 
-    u0 = reduce(hcat, Array(probs[i].u0) for i in 1:length(I))
-    p = reduce(hcat,
-               probs[i].p isa SciMLBase.NullParameters ? probs[i].p : Array(probs[i].p)
-               for i in 1:length(I))
-
     if ensemblealg isa EnsembleGPUAutonomous
         ps = CuArray([SVector{length(probs[i].p)}(probs[i].p) for i in 1:length(I)])
         if typeof(alg) <: GPUTsit5
@@ -338,6 +333,11 @@ function batch_solve(ensembleprob, alg, ensemblealg::EnsembleArrayAlgorithm, I, 
             error("We don't have solvers implemented for this algorithm yet")
         end
     else
+        u0 = reduce(hcat, Array(probs[i].u0) for i in 1:length(I))
+        p = reduce(hcat,
+                   probs[i].p isa SciMLBase.NullParameters ? probs[i].p : Array(probs[i].p)
+                   for i in 1:length(I))
+
         sol, solus = batch_solve_up(ensembleprob, probs, alg, ensemblealg, I, u0, p;
                                     kwargs...)
         [ensembleprob.output_func(SciMLBase.build_solution(probs[i], alg, sol.t, solus[i],

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -327,17 +327,16 @@ function batch_solve(ensembleprob, alg,
                 ts, us = vectorized_solve(cu(probs), ensembleprob.prob, GPUSimpleTsit5();
                                           kwargs...)
             end
-            []
-            # solus = Array(us)
-            # solts = Array(ts)
-            # [@views ensembleprob.output_func(SciMLBase.build_solution(probs[i], alg,
-            #                                                           solts[:, i],
-            #                                                           solus[:, i],
-            #                                                           k = nothing,
-            #                                                           destats = nothing,
-            #                                                           calculate_error = false),
-            #                                  i)[1]
-            #  for i in eachindex(probs)]
+            solus = Array(us)
+            solts = Array(ts)
+            [@views ensembleprob.output_func(SciMLBase.build_solution(probs[i], alg,
+                                                                      solts[:, i],
+                                                                      solus[:, i],
+                                                                      k = nothing,
+                                                                      destats = nothing,
+                                                                      calculate_error = false),
+                                             i)[1]
+             for i in eachindex(probs)]
 
         else
             error("We don't have solvers implemented for this algorithm yet")

--- a/src/gpu_tsit5.jl
+++ b/src/gpu_tsit5.jl
@@ -209,9 +209,7 @@ function tsit5_kernel(probs, _us, _ts, dt,
     i >= length(probs) && return
 
     # get the actual problem for this thread
-    # p = @inbounds ps[i]
     prob = @inbounds probs[i]
-    #prob = remake(_prob; p)
 
     # get the input/output arrays for this thread
     ts = if saveat
@@ -396,7 +394,6 @@ function atsit5_kernel(probs, _us, _ts, dt, abstol, reltol,
     i >= length(probs) && return
 
     # get the actual problem for this thread
-    # p = @inbounds ps[i]
     prob = @inbounds probs[i]
     # get the input/output arrays for this thread
     ts = if saveat

--- a/test/gpu_tsit5_tests.jl
+++ b/test/gpu_tsit5_tests.jl
@@ -16,9 +16,9 @@ prob = ODEProblem{false}(lorenz, u0, tspan, p)
 prob_func = (prob, i, repeat) -> remake(prob, p = p)
 monteprob = EnsembleProblem(prob, prob_func = prob_func, safetycopy = false)
 
-sol = solve(monteprob, GPUTsit5(), EnsembleGPUAutonomous(), trajectories = 10,
+sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(), trajectories = 10,
             adaptive = false, dt = 0.1f0)
-asol = solve(monteprob, GPUTsit5(), EnsembleGPUAutonomous(), trajectories = 10,
+asol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(), trajectories = 10,
              adaptive = true, dt = 0.1f-1, abstol = 1.0f-8, reltol = 1.0f-5)
 
 @test sol.converged == true


### PR DESCRIPTION
Hi,

Wrt the previous discussion on speed-up issues with DiffEqGPU API with the new GPU solvers, I set to bridge the performance gap (46 µs to 10.5 ms 😱) between raw GPU solutions and using the Ensemble DiffEqGPU API. A small commit fix improved the speed by ~ 2.4 ms. (The u0 and p `hcat` was only needed by previous solving techniques).
Pros: It is now faster than `EnsembleGPUArray` and `EnsembleCPUArray`.

Before:

```
julia> @benchmark sol = solve(monteprob, GPUTsit5(), EnsembleGPUAutonomous(), trajectories = 1000,
                              adaptive = false, dt = dt)

BenchmarkTools.Trial: 386 samples with 1 evaluation.
 Range (min … max):   8.805 ms … 40.638 ms  ┊ GC (min … max): 0.00% … 23.29%
 Time  (median):     10.538 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   12.962 ms ±  5.690 ms  ┊ GC (mean ± σ):  8.49% ± 10.88%

  ▄▂▁▄█▄▂ ▁                                    ▁               
  █████████▇▇▇▇▄▇▇▇▄▄▄▆▁▅▁▁▁▁▅▄▁▅▄▁▁▁▁▁▄▆▅▁▄▅▆▇██▅▅▆▁▁▄▁▁▄▅▁▅ ▆
  8.81 ms      Histogram: log(frequency) by time      30.3 ms <

 Memory estimate: 13.86 MiB, allocs estimate: 88075.
```

After:

```
julia> @benchmark sol = solve(monteprob, GPUTsit5(), EnsembleGPUAutonomous(), trajectories = 1000,
                              adaptive = false, dt = dt)
BenchmarkTools.Trial: 497 samples with 1 evaluation.
 Range (min … max):   7.095 ms … 74.585 ms  ┊ GC (min … max): 0.00% … 24.81%
 Time  (median):      8.108 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.051 ms ±  7.866 ms  ┊ GC (mean ± σ):  8.66% ±  9.01%

  ▂█▅ ▁                                                        
  ███▄█▅▁▁▁▄▁▁▁▁▁▁▁▄▁▄▁▁▁▁▁▁▄▁▁▄▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅▄▁▄▅▁▇▇ ▆
  7.09 ms      Histogram: log(frequency) by time      43.3 ms <

 Memory estimate: 5.88 MiB, allocs estimate: 76811.
```

With some profiling and tracking allocations (attached in the next comment), I was able to lower these issues:

- [x] remove `u0` and `p` build from `EnsembleGPUAutonomous`
- [x] Search for better alternatives for building `u0` and `p` in `EnsembleGPUArray`
- [x] Check for `@assert` necessity
- [ ] Transforming GPU `us` arrays to CPU arrays
- [x] Possibility of building Vector{ODESolution} with better speed and lower allocations

@ChrisRackauckas, have a look.