### PR TITLE
Discrete Callbacks for GPUTsit5

### DIFF
--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -375,7 +375,7 @@ function batch_solve_up_kernel(ensembleprob, probs, alg, ensemblealg, I, adaptiv
                                    kwargs...)
     else
         ts, us = vectorized_solve(cu(probs), ensembleprob.prob, GPUSimpleTsit5();
-                                  callback= _callback, kwargs...)
+                                  callback = _callback, kwargs...)
     end
     solus = Array(us)
     solts = Array(ts)

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -375,7 +375,7 @@ function batch_solve_up_kernel(ensembleprob, probs, alg, ensemblealg, I, adaptiv
                                    kwargs...)
     else
         ts, us = vectorized_solve(cu(probs), ensembleprob.prob, GPUSimpleTsit5();
-                                  kwargs..., callback = _callback)
+                                  callback= _callback, kwargs...)
     end
     solus = Array(us)
     solts = Array(ts)

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -150,6 +150,24 @@ struct FakeIntegrator{uType, tType, P}
     p::P
 end
 
+struct GPUDiscreteCallback{F1, F2, F3, F4} <: SciMLBase.AbstractDiscreteCallback
+    condition::F1
+    affect!::F2
+    initialize::F3
+    finalize::F4
+    #save_positions::BitArray{1}
+    function GPUDiscreteCallback(condition::F1, affect!::F2,
+                                 initialize::F3, finalize::F4) where {F1, F2, F3, F4}
+        new{F1, F2, F3, F4}(condition,
+                            affect!, initialize, finalize)
+    end
+end
+function GPUDiscreteCallback(condition, affect!;
+                             initialize = SciMLBase.INITIALIZE_DEFAULT,
+                             finalize = SciMLBase.FINALIZE_DEFAULT)
+    GPUDiscreteCallback(condition, affect!, initialize, finalize)
+end
+
 abstract type EnsembleArrayAlgorithm <: SciMLBase.EnsembleAlgorithm end
 abstract type EnsembleKernelAlgorithm <: SciMLBase.EnsembleAlgorithm end
 struct EnsembleCPUArray <: EnsembleArrayAlgorithm end
@@ -319,16 +337,8 @@ function batch_solve(ensembleprob, alg,
 
     if ensemblealg isa EnsembleGPUKernel
         if typeof(alg) <: GPUTsit5
-            #Adaptive version only works with saveat
-            if adaptive
-                ts, us = vectorized_asolve(cu(probs), ensembleprob.prob, GPUSimpleATsit5();
-                                           kwargs...)
-            else
-                ts, us = vectorized_solve(cu(probs), ensembleprob.prob, GPUSimpleTsit5();
-                                          kwargs...)
-            end
-            solus = Array(us)
-            solts = Array(ts)
+            solts, solus = batch_solve_up_kernel(ensembleprob, probs, alg, ensemblealg, I,
+                                                 adaptive; kwargs...)
             [@views ensembleprob.output_func(SciMLBase.build_solution(probs[i], alg,
                                                                       solts[:, i],
                                                                       solus[:, i],
@@ -354,6 +364,22 @@ function batch_solve(ensembleprob, alg,
                                                            retcode = sol.retcode), i)[1]
          for i in 1:length(probs)]
     end
+end
+
+function batch_solve_up_kernel(ensembleprob, probs, alg, ensemblealg, I, adaptive;
+                               kwargs...)
+    _callback = generate_callback(probs[1], length(I), ensemblealg; kwargs...)
+    #Adaptive version only works with saveat
+    if adaptive
+        ts, us = vectorized_asolve(cu(probs), ensembleprob.prob, GPUSimpleATsit5();
+                                   kwargs...)
+    else
+        ts, us = vectorized_solve(cu(probs), ensembleprob.prob, GPUSimpleTsit5();
+                                  kwargs..., callback = _callback)
+    end
+    solus = Array(us)
+    solts = Array(ts)
+    (solts, solus)
 end
 
 function batch_solve_up(ensembleprob, probs, alg, ensemblealg, I, u0, p; kwargs...)
@@ -644,7 +670,8 @@ function generate_problem(prob::SDEProblem, u0, p, jac_prototype, colorvec)
                       prob.kwargs...)
 end
 
-function generate_callback(callback::DiscreteCallback, I, ensemblealg)
+function generate_callback(callback::Union{DiscreteCallback, GPUDiscreteCallback}, I,
+                           ensemblealg)
     if ensemblealg isa EnsembleGPUArray
         cur = CuArray([false for i in 1:I])
     else
@@ -674,8 +701,9 @@ function generate_callback(callback::DiscreteCallback, I, ensemblealg)
                                               dependencies = Event(version),
                                               workgroupsize = wgs))
     end
-
-    return DiscreteCallback(condition, affect!, save_positions = callback.save_positions)
+    return typeof(callback) <: GPUDiscreteCallback ?
+           callback :
+           DiscreteCallback(condition, affect!, save_positions = callback.save_positions)
 end
 
 function generate_callback(callback::ContinuousCallback, I, ensemblealg)
@@ -921,6 +949,6 @@ include("gpu_tsit5.jl")
 
 export EnsembleCPUArray, EnsembleGPUArray, EnsembleGPUKernel, LinSolveGPUSplitFactorize
 
-export GPUTsit5
+export GPUTsit5, GPUDiscreteCallback
 
 end # module

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -150,22 +150,24 @@ struct FakeIntegrator{uType, tType, P}
     p::P
 end
 
-struct GPUDiscreteCallback{F1, F2, F3, F4} <: SciMLBase.AbstractDiscreteCallback
+struct GPUDiscreteCallback{F1, F2, F3, F4, F5} <: SciMLBase.AbstractDiscreteCallback
     condition::F1
     affect!::F2
     initialize::F3
     finalize::F4
-    #save_positions::BitArray{1}
+    save_positions::F5
     function GPUDiscreteCallback(condition::F1, affect!::F2,
-                                 initialize::F3, finalize::F4) where {F1, F2, F3, F4}
-        new{F1, F2, F3, F4}(condition,
-                            affect!, initialize, finalize)
+                                 initialize::F3, finalize::F4,
+                                 save_positions::F5) where {F1, F2, F3, F4, F5}
+        new{F1, F2, F3, F4, F5}(condition,
+                                affect!, initialize, finalize, save_positions)
     end
 end
 function GPUDiscreteCallback(condition, affect!;
                              initialize = SciMLBase.INITIALIZE_DEFAULT,
-                             finalize = SciMLBase.FINALIZE_DEFAULT)
-    GPUDiscreteCallback(condition, affect!, initialize, finalize)
+                             finalize = SciMLBase.FINALIZE_DEFAULT,
+                             save_positions = (true, true))
+    GPUDiscreteCallback(condition, affect!, initialize, finalize, save_positions)
 end
 
 abstract type EnsembleArrayAlgorithm <: SciMLBase.EnsembleAlgorithm end

--- a/src/gpu_tsit5.jl
+++ b/src/gpu_tsit5.jl
@@ -282,7 +282,7 @@ end
     k7 = f(integ.u, p, t + dt)
 
     @inbounds begin # Necessary for interpolation
-        integ.k1 = k7
+        integ.k1 = k1
         integ.k2 = k2
         integ.k3 = k3
         integ.k4 = k4
@@ -305,8 +305,7 @@ end
 #  true: ts is a vector of timestamps to read from
 #  false: each ODE has its own timestamps, so ts is a vector to write to
 function tsit5_kernel(probs, _us, _ts, dt, callback, tstops,
-                      saveat, ::Val{save_everystep}) where save_everystep
-
+                      saveat, ::Val{save_everystep}) where {save_everystep}
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     i > length(probs) && return
 

--- a/src/gpu_tsit5.jl
+++ b/src/gpu_tsit5.jl
@@ -145,6 +145,9 @@ function vectorized_solve(probs, prob::ODEProblem, alg::GPUSimpleTsit5;
         us = CuMatrix{typeof(prob.u0)}(undef, (length(ts), length(ps)))
     end
 
+    # Handle tstops
+    tstops = cu(tstops)
+
     kernel = @cuda launch=false tsit5_kernel(probs, us, ts, dt, callback, tstops,
                                              Val(saveat !== nothing), Val(save_everystep))
     if debug
@@ -201,6 +204,24 @@ end
     end
     integrator.u_modified, saved_in_cb
 end
+
+
+@inline function apply_discrete_callback!(integrator,ts, us, callback::GPUDiscreteCallback, args...)
+    apply_discrete_callback!(integrator, ts, us, apply_discrete_callback!(integrator, ts, us, callback)...,
+                             args...)
+end
+
+@inline function apply_discrete_callback!(integrator, ts, us, discrete_modified::Bool, saved_in_cb::Bool, callback::GPUDiscreteCallback, args...)
+    bool, saved_in_cb2 = apply_discrete_callback!(integrator, ts, us, apply_discrete_callback!(integrator, ts, us, callback)...,args...)
+    discrete_modified || bool, saved_in_cb || saved_in_cb2
+end
+
+
+@inline function apply_discrete_callback!(integrator, ts, us, discrete_modified::Bool, saved_in_cb::Bool, callback::GPUDiscreteCallback)
+    bool, saved_in_cb2 = apply_discrete_callback!(integrator, ts, us, callback)
+    discrete_modified || bool, saved_in_cb || saved_in_cb2
+end
+
 
 @inline function step!(integ::GPUT5I{false, S, T}, ts, us) where {T, S}
     c1, c2, c3, c4, c5, c6 = integ.cs
@@ -261,8 +282,8 @@ end
     end
 
     if integ.cb !== nothing
-        discrete_modified, saved_in_cb = apply_discrete_callback!(integ, ts, us,
-                                                                  integ.cb)
+        _, saved_in_cb = apply_discrete_callback!(integ, ts, us,
+                                                                  integ.cb.discrete_callbacks...)
     else
         saved_in_cb = false
     end

--- a/src/gpu_tsit5.jl
+++ b/src/gpu_tsit5.jl
@@ -221,7 +221,6 @@ end
     ## Check if tstops are within the range of time-series
     if integ.tstops !== nothing && integ.tstops_idx <= length(integ.tstops) &&
        integ.tstops[integ.tstops_idx] < integ.t + integ.dt
-        @cuprintln integ.u[1]
         integ.t = integ.tstops[integ.tstops_idx]
         integ.tstops_idx += 1
     else
@@ -291,7 +290,7 @@ function tsit5_kernel(probs, _us, _ts, dt, callback, tstops,
     us = @inbounds view(_us, :, i)
 
     integ = gputsit5_init(prob.f, false, prob.u0, prob.tspan[1], dt, prob.p, tstops,
-    callback, save_everystep)
+                          callback, save_everystep)
 
     @inbounds ts[integ.step_idx] = prob.tspan[1]
     @inbounds us[integ.step_idx] = prob.u0

--- a/src/gpu_tsit5.jl
+++ b/src/gpu_tsit5.jl
@@ -220,7 +220,7 @@ end
     adv_integ = true
     ## Check if tstops are within the range of time-series
     if integ.tstops !== nothing && integ.tstops_idx <= length(integ.tstops) &&
-       integ.tstops[integ.tstops_idx] < integ.t + integ.dt
+       integ.tstops[integ.tstops_idx] <= integ.t + integ.dt
         integ.t = integ.tstops[integ.tstops_idx]
         integ.tstops_idx += 1
     else

--- a/test/gpu_tsit5_tests.jl
+++ b/test/gpu_tsit5_tests.jl
@@ -73,7 +73,7 @@ bench_sol = solve(prob, Tsit5(),
                   tstops = [4.0f0])
 
 @test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 1e-6
-@test norm(bench_sol.u - sol[1].u) < 1e-6
+@test norm(bench_sol.u - sol[1].u) < 3e-5
 
 @info "Callback: CallbackSets"
 
@@ -96,14 +96,14 @@ cb = CallbackSet(cb_1, cb_2)
 sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(),
             trajectories = 2,
             adaptive = false, dt = 1.0f0, callback = gpu_cb, merge_callbacks = true,
-            tstops = CuArray([24.0f0, 40.0f0]))
+            tstops = [24.0f0, 40.0f0])
 
 bench_sol = solve(prob, Tsit5(),
                   adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
-                  tstops = [[24.0f0, 40.0f0]])
+                  tstops = [24.0f0, 40.0f0])
 
 @test norm(bench_sol(24.0f0) - sol[1](24.0f0)) < 1e-6
 @test norm(bench_sol(40.0f0) - sol[1](40.0f0)) < 1e-6
-@test norm(bench_sol.u - sol[1].u) < 1e-6
+@test norm(bench_sol.u - sol[1].u) < 2e-5
 
-## Float64 Tests
+# Float64 Tests

--- a/test/gpu_tsit5_tests.jl
+++ b/test/gpu_tsit5_tests.jl
@@ -52,7 +52,7 @@ function f(u, p, t)
 end
 
 u0 = @SVector [10.0f0]
-prob = ODEProblem{false}(f, u0, (0.0f0, 10.0f0))
+prob = ODEProblem{false}(f, u0, (0.0f0, 100.0f0))
 prob_func = (prob, i, repeat) -> remake(prob, p = prob.p)
 monteprob = EnsembleProblem(prob, safetycopy = false)
 
@@ -65,12 +65,14 @@ cb = DiscreteCallback(condition, affect!)
 
 sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(),
             trajectories = 2,
-            adaptive = false, dt = 0.01f0, callback = gpu_cb, merge_callbacks = true,
+            adaptive = false, dt = 1.0f0, callback = gpu_cb, merge_callbacks = true,
             tstops = CuArray([4.0f0]))
 
 bench_sol = solve(prob, Tsit5(),
-                  adaptive = false, dt = 0.01f0, callback = cb, merge_callbacks = true,
+                  adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
                   tstops = [4.0f0])
 
-@test norm(bench_sol(4.01f0) - sol[1](4.01f0)) < 2e-2
-@test norm(bench_sol.u - sol[1].u) < 2e-2
+@test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 1e-6
+@test norm(bench_sol.u - sol[1].u) < 1e-6
+
+## Float64 Tests

--- a/test/gpu_tsit5_tests.jl
+++ b/test/gpu_tsit5_tests.jl
@@ -111,8 +111,6 @@ condition_1(u, t, integrator) = t == 24.0f0
 
 condition_2(u, t, integrator) = t == 40.0f0
 
-affect!(integrator) = integrator.u += @SVector[10.0f0]
-
 gpu_cb_1 = GPUDiscreteCallback(condition_1, affect!)
 gpu_cb_2 = GPUDiscreteCallback(condition_2, affect!)
 


### PR DESCRIPTION
Hi,

I have started to add a rudimentary implementation of discrete callbacks. It works for now but needs more work for better support.

- [x] GPU compatible versions of `apply_discrete_callback!` and `savevalues!`https://github.com/SciML/DiffEqBase.jl/blob/410ecd570dfd4b1322d7f62f67e6139f05d7498e/src/callbacks.jl#L593
- [x] Understand and apply the usage of `doaffect` https://github.com/SciML/JumpProcesses.jl/blob/master/src/SSA_stepper.jl#L256-L258
- [x] Support for `CallbackSet`
- [x] Workaround for save_positions (They are `BitArray`)

This currently works in the un-adaptive version. It does not push the `tstops` into the `ts` time-series, because its size is pre-determined. I think `CuMatrix{typeof(dt)}(undef, len(original_ts) + len(tstops), length(probs))` could work, but it may have duplicates.

I'll proceed for more robustness and alignment toward callbacks implemented in DiffEqBase. I believe correctly modifying the DiffEqBase callback functions would solve these problems. 