### PR TITLE
Add support for terminate! in EnsembleGPUKernel

### DIFF
--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -1081,5 +1081,6 @@ include("solve.jl")
 export EnsembleCPUArray, EnsembleGPUArray, EnsembleGPUKernel, LinSolveGPUSplitFactorize
 
 export GPUTsit5, GPUVern7, GPUVern9
+export terminate!
 
 end # module

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -40,6 +40,18 @@ function savevalues!(integrator::DiffEqBase.AbstractODEIntegrator{AlgType, IIP, 
     saved, savedexactly
 end
 
+@inline function DiffEqBase.terminate!(integrator::DiffEqBase.AbstractODEIntegrator{AlgType,
+                                                                                    IIP, S,
+                                                                                    T}) where {
+                                                                                               AlgType <:
+                                                                                               GPUODEAlgorithm,
+                                                                                               IIP,
+                                                                                               S,
+                                                                                               T
+                                                                                               }
+    integrator.retcode = ReturnCode.Terminated
+end
+
 @inline function apply_discrete_callback!(integrator::DiffEqBase.AbstractODEIntegrator{
                                                                                        AlgType,
                                                                                        IIP,

--- a/src/integrators/types.jl
+++ b/src/integrators/types.jl
@@ -41,6 +41,7 @@ mutable struct GPUTsit5Integrator{IIP, S, T, ST, P, F, TS, CB} <:
     cs::SVector{6, T}     # ci factors cache: time coefficients
     as::SVector{21, T}    # aij factors cache: solution coefficients
     rs::SVector{22, T}    # rij factors cache: interpolation coefficients
+    retcode::DiffEqBase.ReturnCode.T
 end
 const GPUT5I = GPUTsit5Integrator
 
@@ -97,6 +98,7 @@ mutable struct GPUATsit5Integrator{IIP, S, T, ST, P, F, N, TOL, Q, TS, CB} <:
     abstol::TOL
     reltol::TOL
     internalnorm::N       # function that computes the error EEst based on state
+    retcode::DiffEqBase.ReturnCode.T
 end
 
 const GPUAT5I = GPUATsit5Integrator
@@ -145,6 +147,7 @@ mutable struct GPUV7Integrator{IIP, S, T, ST, P, F, TS, CB, TabType} <:
     k9::S
     k10::S
     tab::TabType
+    retcode::DiffEqBase.ReturnCode.T
 end
 const GPUV7I = GPUV7Integrator
 
@@ -193,6 +196,7 @@ mutable struct GPUAV7Integrator{IIP, S, T, ST, P, F, N, TOL, Q, TS, CB, TabType}
     abstol::TOL
     reltol::TOL
     internalnorm::N       # function that computes the error EEst based on state
+    retcode::DiffEqBase.ReturnCode.T
 end
 
 const GPUAV7I = GPUAV7Integrator
@@ -238,6 +242,7 @@ mutable struct GPUV9Integrator{IIP, S, T, ST, P, F, TS, CB, TabType} <:
     k9::S
     k10::S
     tab::TabType
+    retcode::DiffEqBase.ReturnCode.T
 end
 const GPUV9I = GPUV9Integrator
 
@@ -286,6 +291,7 @@ mutable struct GPUAV9Integrator{IIP, S, T, ST, P, F, N, TOL, Q, TS, CB, TabType}
     abstol::TOL
     reltol::TOL
     internalnorm::N       # function that computes the error EEst based on state
+    retcode::DiffEqBase.ReturnCode.T
 end
 
 const GPUAV9I = GPUAV9Integrator
@@ -320,7 +326,8 @@ end
                                                 last_event_error,
                                                 copy(u0), copy(u0), copy(u0), copy(u0),
                                                 copy(u0),
-                                                copy(u0), copy(u0), cs, as, rs)
+                                                copy(u0), copy(u0), cs, as, rs,
+                                                DiffEqBase.ReturnCode.Default)
 end
 
 @inline function gpuatsit5_init(f::F, IIP::Bool, u0::S, t0::T, tf::T, dt::T, p::P,
@@ -361,7 +368,8 @@ end
                                                                            rs, qoldinit,
                                                                            abstol,
                                                                            reltol,
-                                                                           internalnorm)
+                                                                           internalnorm,
+                                                                           DiffEqBase.ReturnCode.Default)
 end
 
 @inline function gpuvern7_init(f::F, IIP::Bool, u0::S, t0::T, dt::T,
@@ -390,7 +398,8 @@ end
                                                              copy(u0),
                                                              copy(u0),
                                                              copy(u0), copy(u0), copy(u0),
-                                                             copy(u0), copy(u0), tab)
+                                                             copy(u0), copy(u0), tab,
+                                                             DiffEqBase.ReturnCode.Default)
 end
 
 @inline function gpuavern7_init(f::F, IIP::Bool, u0::S, t0::T, tf::T, dt::T, p::P,
@@ -445,7 +454,8 @@ end
                                                                                         qoldinit,
                                                                                         abstol,
                                                                                         reltol,
-                                                                                        internalnorm)
+                                                                                        internalnorm,
+                                                                                        DiffEqBase.ReturnCode.Default)
 end
 
 @inline function gpuvern9_init(f::F, IIP::Bool, u0::S, t0::T, dt::T,
@@ -473,7 +483,8 @@ end
                                                              copy(u0), copy(u0), copy(u0),
                                                              copy(u0), copy(u0), copy(u0),
                                                              copy(u0), copy(u0),
-                                                             copy(u0), copy(u0), tab)
+                                                             copy(u0), copy(u0), tab,
+                                                             DiffEqBase.ReturnCode.Default)
 end
 
 @inline function gpuavern9_init(f::F, IIP::Bool, u0::S, t0::T, tf::T, dt::T, p::P,
@@ -528,5 +539,6 @@ end
                                                                                         qoldinit,
                                                                                         abstol,
                                                                                         reltol,
-                                                                                        internalnorm)
+                                                                                        internalnorm,
+                                                                                        DiffEqBase.ReturnCode.Default)
 end

--- a/src/perform_step/gpu_tsit5_perform_step.jl
+++ b/src/perform_step/gpu_tsit5_perform_step.jl
@@ -98,7 +98,7 @@ function tsit5_kernel(probs, _us, _ts, dt, callback, tstops, nsteps,
 
     integ.step_idx += 1
     # FSAL
-    while integ.t < tspan[2]
+    while integ.t < tspan[2] && integ.retcode != DiffEqBase.ReturnCode.Terminated
         saved_in_cb = step!(integ, ts, us)
         !saved_in_cb && savevalues!(integ, ts, us)
     end
@@ -257,7 +257,7 @@ function atsit5_kernel(probs, _us, _ts, dt, callback, tstops, abstol, reltol,
         @inbounds us[1] = u0
     end
 
-    while integ.t < tspan[2]
+    while integ.t < tspan[2] && integ.retcode != DiffEqBase.ReturnCode.Terminated
         saved_in_cb = step!(integ, ts, us)
         !saved_in_cb && savevalues!(integ, ts, us)
     end

--- a/src/perform_step/gpu_vern7_perform_step.jl
+++ b/src/perform_step/gpu_vern7_perform_step.jl
@@ -106,7 +106,7 @@ function vern7_kernel(probs, _us, _ts, dt, callback, tstops, nsteps,
 
     integ.step_idx += 1
     # FSAL
-    while integ.t < tspan[2]
+    while integ.t < tspan[2] && integ.retcode != DiffEqBase.ReturnCode.Terminated
         saved_in_cb = step!(integ, ts, us)
         !saved_in_cb && savevalues!(integ, ts, us)
     end
@@ -282,7 +282,7 @@ function avern7_kernel(probs, _us, _ts, dt, callback, tstops, abstol, reltol,
         @inbounds us[1] = u0
     end
 
-    while integ.t < tspan[2]
+    while integ.t < tspan[2] && integ.retcode != DiffEqBase.ReturnCode.Terminated
         saved_in_cb = step!(integ, ts, us)
         !saved_in_cb && savevalues!(integ, ts, us)
     end

--- a/src/perform_step/gpu_vern9_perform_step.jl
+++ b/src/perform_step/gpu_vern9_perform_step.jl
@@ -133,7 +133,7 @@ function vern9_kernel(probs, _us, _ts, dt, callback, tstops, nsteps,
 
     integ.step_idx += 1
     # FSAL
-    while integ.t < tspan[2]
+    while integ.t < tspan[2] && integ.retcode != DiffEqBase.ReturnCode.Terminated
         saved_in_cb = step!(integ, ts, us)
         !saved_in_cb && savevalues!(integ, ts, us)
     end
@@ -341,7 +341,7 @@ function avern9_kernel(probs, _us, _ts, dt, callback, tstops, abstol, reltol,
         @inbounds us[1] = u0
     end
 
-    while integ.t < tspan[2]
+    while integ.t < tspan[2] && integ.retcode != DiffEqBase.ReturnCode.Terminated
         saved_in_cb = step!(integ, ts, us)
         !saved_in_cb && savevalues!(integ, ts, us)
     end


### PR DESCRIPTION
MWE:
```
using DiffEqGPU, OrdinaryDiffEq, StaticArrays, LinearAlgebra, CUDA

function f(u, p, t)
    du1 = -u[1]
    return SVector{1}(du1)
end

u0 = @SVector [10.0f0]
prob = ODEProblem{false}(f, u0, (0.0f0, 10.0f0))
prob_func = (prob, i, repeat) -> remake(prob, p = prob.p)
monteprob = EnsembleProblem(prob, safetycopy = false)

condition(u, t, integrator) = t == 2.40f0

function affect!(integrator)
    integrator.u += @SVector[10.0f0]
    terminate!(integrator)
end

cb = DiscreteCallback(condition, affect!; save_positions = (false, false))
```

```
sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(),
                trajectories = 2,
                adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
                tstops = [2.40f0])

  bench_sol = solve(prob, Tsit5(),
                    adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
                    tstops = [2.40f0])
```

```
julia> sol[1]
retcode: Default
Interpolation: 1st order linear
t: 12-element view(::Matrix{Float32}, :, 1) with eltype Float32:
 0.0
 1.0
 2.0
 2.4
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
u: 12-element view(::Matrix{SVector{1, Float32}}, :, 1) with eltype SVector{1, Float32}:
 [10.0]
 [3.6809897]
 [1.3549666]
 [0.90826195]
 [0.0]
 [0.0]
 [0.0]
 [0.0]
 [0.0]
 [0.0]
 [0.0]
 [0.0]
```
```
julia> bench_sol = solve(prob, Tsit5(),
                         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
                         tstops = [2.40f0])
retcode: Terminated
Interpolation: specialized 4th order "free" interpolation
t: 4-element Vector{Float32}:
 0.0
 1.0
 2.0
 2.4
u: 4-element Vector{SVector{1, Float32}}:
 [10.0]
 [3.6809988]
 [1.3549728]
 [0.90826607]
```