### PR TITLE
Add support for random time span within trajectories

### DIFF
--- a/src/perform_step/gpu_em_perform_step.jl
+++ b/src/perform_step/gpu_em_perform_step.jl
@@ -10,6 +10,10 @@ function em_kernel(probs, _us, _ts, dt,
     ts = @inbounds view(_ts, :, i)
     us = @inbounds view(_us, :, i)
 
+    _saveat = get(prob.kwargs, :saveat, nothing)
+
+    saveat = _saveat === nothing ? saveat : _saveat
+
     f = prob.f
     g = prob.g
     u0 = prob.u0

--- a/src/perform_step/gpu_tsit5_perform_step.jl
+++ b/src/perform_step/gpu_tsit5_perform_step.jl
@@ -78,6 +78,10 @@ function tsit5_kernel(probs, _us, _ts, dt, callback, tstops, nsteps,
     ts = @inbounds view(_ts, :, i)
     us = @inbounds view(_us, :, i)
 
+    _saveat = get(prob.kwargs, :saveat, nothing)
+
+    saveat = _saveat === nothing ? saveat : _saveat
+
     integ = gputsit5_init(prob.f, false, prob.u0, prob.tspan[1], dt, prob.p, tstops,
                           callback, save_everystep, saveat)
 
@@ -232,6 +236,10 @@ function atsit5_kernel(probs, _us, _ts, dt, callback, tstops, abstol, reltol,
     ts = @inbounds view(_ts, :, i)
     us = @inbounds view(_us, :, i)
     # TODO: optimize contiguous view to return a CuDeviceArray
+
+    _saveat = get(prob.kwargs, :saveat, nothing)
+
+    saveat = _saveat === nothing ? saveat : _saveat
 
     u0 = prob.u0
     tspan = prob.tspan

--- a/src/perform_step/gpu_vern7_perform_step.jl
+++ b/src/perform_step/gpu_vern7_perform_step.jl
@@ -86,6 +86,10 @@ function vern7_kernel(probs, _us, _ts, dt, callback, tstops, nsteps,
     ts = @inbounds view(_ts, :, i)
     us = @inbounds view(_us, :, i)
 
+    _saveat = get(prob.kwargs, :saveat, nothing)
+
+    saveat = _saveat === nothing ? saveat : _saveat
+
     integ = gpuvern7_init(prob.f, false, prob.u0, prob.tspan[1], dt, prob.p, tstops,
                           callback, save_everystep, saveat)
 
@@ -257,6 +261,10 @@ function avern7_kernel(probs, _us, _ts, dt, callback, tstops, abstol, reltol,
     ts = @inbounds view(_ts, :, i)
     us = @inbounds view(_us, :, i)
     # TODO: optimize contiguous view to return a CuDeviceArray
+
+    _saveat = get(prob.kwargs, :saveat, nothing)
+
+    saveat = _saveat === nothing ? saveat : _saveat
 
     u0 = prob.u0
     tspan = prob.tspan

--- a/src/perform_step/gpu_vern9_perform_step.jl
+++ b/src/perform_step/gpu_vern9_perform_step.jl
@@ -113,6 +113,10 @@ function vern9_kernel(probs, _us, _ts, dt, callback, tstops, nsteps,
     ts = @inbounds view(_ts, :, i)
     us = @inbounds view(_us, :, i)
 
+    _saveat = get(prob.kwargs, :saveat, nothing)
+
+    saveat = _saveat === nothing ? saveat : _saveat
+
     integ = gpuvern9_init(prob.f, false, prob.u0, prob.tspan[1], dt, prob.p, tstops,
                           callback, save_everystep, saveat)
 
@@ -316,6 +320,10 @@ function avern9_kernel(probs, _us, _ts, dt, callback, tstops, abstol, reltol,
     ts = @inbounds view(_ts, :, i)
     us = @inbounds view(_us, :, i)
     # TODO: optimize contiguous view to return a CuDeviceArray
+
+    _saveat = get(prob.kwargs, :saveat, nothing)
+
+    saveat = _saveat === nothing ? saveat : _saveat
 
     u0 = prob.u0
     tspan = prob.tspan


### PR DESCRIPTION
Fixes #141 
MWE:

```
using DiffEqGPU, OrdinaryDiffEq, StaticArrays, LinearAlgebra, CUDA
function lorenz(u, p, t)
    σ = p[1]
    ρ = p[2]
    β = p[3]
    du1 = σ * (u[2] - u[1])
    du2 = u[1] * (ρ - u[3]) - u[2]
    du3 = u[1] * u[2] - β * u[3]
    return SVector{3}(du1, du2, du3)
end

u0 = @SVector [1.0f0; 0.0f0; 0.0f0]
tspan = (0.0f0, 10.0f0)
p = @SVector [10.0f0, 28.0f0, 8 / 3.0f0]
prob = ODEProblem{false}(lorenz, u0, tspan, p)

saveats = 1.f0:1.f0:10.f0


monteprob = EnsembleProblem(prob, prob_func =  (prob, i, repeat) -> remake(prob; tspan = (0.f0, saveats[i]), saveat = LinRange(0.f0,saveats[i],10), safetycopy = false))

alg = GPUTsit5()

sol = solve(monteprob, alg, EnsembleGPUKernel(0.0), trajectories = 10,
            adaptive = false, dt = 0.01f0, save_everystep = false)
```