### PR TITLE
Attempt to isolate cause of dynamic allocation in continuous callbacks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SimpleDiffEq = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
+SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
@@ -47,8 +48,8 @@ julia = "1.6"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-DiffEqSensitivity = "41bf760c-e81c-5289-8e54-58b1f1f8abe2"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
+DiffEqSensitivity = "41bf760c-e81c-5289-8e54-58b1f1f8abe2"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -20,6 +20,7 @@ using LinearSolve
 using Adapt, SimpleDiffEq, StaticArrays
 using Parameters, MuladdMacro
 using Random
+using SimpleNonlinearSolve
 
 @kernel function gpu_kernel(f, du, @Const(u), @Const(p), @Const(t))
     i = @index(Global, Linear)


### PR DESCRIPTION
The PR attempts to remove closure to better isolate the issue.
```
using DiffEqGPU, SimpleDiffEq, StaticArrays, CUDA, BenchmarkTools, NonlinearSolve
#using OrdinaryDiffEq

CUDA.allowscalar(false)

function f(u, p, t)
    du1 = u[2]
    du2 = -p[1]
    return SVector{2}(du1, du2)
end

u0 = @SVector[45.0f0, 0.0f0]
tspan = (0.0f0, 1.0f0)
p = @SVector [10.0f0]
prob = ODEProblem{false}(f, u0, tspan, p)
prob_func = (prob, i, repeat) -> remake(prob, p = prob.p)
monteprob = EnsembleProblem(prob, safetycopy = false)

function affect!(integrator)
    integrator.u += @SVector[0.0f0, -2.0f0] .* integrator.u
end

function condition(u, t, integrator)
   u[1]
end

cb = ContinuousCallback(condition, affect!; save_positions = (false, false))
sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(),
            trajectories = 2,
            adaptive = false, dt = 0.1f0, callback = cb, merge_callbacks = true)

@device_code_llvm dump_module=true sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(),
                                               trajectories = 2,
                                               adaptive = false, dt = 0.1f0, callback = cb, merge_callbacks = true)
```