### PR TITLE
support non-array parameters

### DIFF
--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -21,12 +21,20 @@ using Random
 
 @kernel function gpu_kernel(f, du, @Const(u), @Const(p), @Const(t))
     i = @index(Global, Linear)
-    @views @inbounds f(du[:, i], u[:, i], p[:, i], t)
+    if eltype(p) <: Number
+        @views @inbounds f(du[:, i], u[:, i], p[:, i], t)
+    else
+        @views @inbounds f(du[:, i], u[:, i], p[i], t)
+    end
 end
 
 @kernel function gpu_kernel_oop(f, du, @Const(u), @Const(p), @Const(t))
     i = @index(Global, Linear)
-    @views @inbounds x = f(u[:, i], p[:, i], t)
+    if eltype(p) <: Number
+        @views @inbounds x = f(u[:, i], p[:, i], t)
+    else
+        @views @inbounds x = f(u[:, i], p[i], t)
+    end
     @inbounds for j in 1:size(du, 1)
         du[j, i] = x[j]
     end
@@ -35,13 +43,21 @@ end
 @kernel function jac_kernel(f, J, @Const(u), @Const(p), @Const(t))
     i = @index(Global, Linear) - 1
     section = (1 + (i * size(u, 1))):((i + 1) * size(u, 1))
-    @views @inbounds f(J[section, section], u[:, i + 1], p[:, i + 1], t)
+    if eltype(p) <: Number
+        @views @inbounds f(J[section, section], u[:, i + 1], p[:, i + 1], t)
+    else
+        @views @inbounds f(J[section, section], u[:, i + 1], p[i + 1], t)
+    end
 end
 
 @kernel function jac_kernel_oop(f, J, @Const(u), @Const(p), @Const(t))
     i = @index(Global, Linear) - 1
     section = (1 + (i * size(u, 1))):((i + 1) * size(u, 1))
-    @views @inbounds x = f(u[:, i + 1], p[:, i + 1], t)
+    if eltype(p) <: Number
+        @views @inbounds x = f(u[:, i + 1], p[:, i + 1], t)
+    else
+        @views @inbounds x = f(u[:, i + 1], p[i + 1], t)
+    end
     @inbounds for j in section, k in section
         J[k, j] = x[k, j]
     end
@@ -701,7 +717,7 @@ function batch_solve(ensembleprob, alg,
                     probs)
         u0 = reduce(hcat, Array(probs[i].u0) for i in 1:length(I))
         p = reduce(hcat,
-                   probs[i].p isa SciMLBase.NullParameters ? probs[i].p : Array(probs[i].p)
+                   probs[i].p isa AbstractArray ? Array(probs[i].p) : probs[i].p
                    for i in 1:length(I))
 
         sol, solus = batch_solve_up(ensembleprob, probs, alg, ensemblealg, I, u0, p;


### PR DESCRIPTION
In case the parameters are not an array of numbers, they get concatenated into a matrix, and then indexing returns an 1x1 matrix rather than the type of the parameters. I think this went unnoticed because it only worked for NullParameters and nobody actually looks at the NullParameters to see they are not an array.

What was happening, vs what's happening now:

```julia
julia> p
1×8 Matrix{LorenzParameters}:
 LorenzParameters(0.674407, 7.73146, 1.87812)  LorenzParameters(4.37845, 6.03229, 1.87617)  …  LorenzParameters(5.31718, 2.12004, 2.46161)  LorenzParameters(3.91543, 7.20726, 1.17673)

julia> Base.maybeview(p, :, 1)
1-element view(::Matrix{LorenzParameters}, :, 1) with eltype LorenzParameters:
 LorenzParameters(0.6744069f0, 7.7314587f0, 1.8781189f0)

julia> Base.maybeview(p, 1)
LorenzParameters(0.6744069f0, 7.7314587f0, 1.8781189f0)
```

fixes #248