### PR TITLE
Allow large problems to work with stiff ODE solvers in `EnsembleGPUKernel`

### DIFF
--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -20,6 +20,9 @@ using Parameters, MuladdMacro
 using Random
 using Setfield
 using ForwardDiff
+import StaticArrays: StaticVecOrMat, @_inline_meta
+# import LinearAlgebra: \
+import StaticArrays: LU, StaticLUMatrix, arithmetic_closure
 
 """
 Wrapper for modifying parameters to contain additional data. Useful for simulating
@@ -1594,6 +1597,8 @@ function tmap(f, args...)
     reduce(vcat, batch_data)
 end
 
+include("linalg/lu.jl")
+include("linalg/linsolve.jl")
 include("alg_utils.jl")
 include("integrators/types.jl")
 include("integrators/stiff/types.jl")

--- a/src/linalg/linsolve.jl
+++ b/src/linalg/linsolve.jl
@@ -1,0 +1,86 @@
+# Credits: StaticArrays.jl
+# https://github.com/JuliaArrays/StaticArrays.jl/blob/master/src/solve.jl
+
+@inline function linear_solve(A::StaticMatrix, b::StaticVecOrMat)
+    _linear_solve(Size(A), Size(b), A, b)
+end
+
+@inline function _linear_solve(::Size{(1, 1)},
+    ::Size{(1,)},
+    a::StaticMatrix{<:Any, <:Any, Ta},
+    b::StaticVector{<:Any, Tb}) where {Ta, Tb}
+    @inbounds return similar_type(b, typeof(a[1] \ b[1]))(a[1] \ b[1])
+end
+
+@inline function _linear_solve(::Size{(2, 2)},
+    ::Size{(2,)},
+    a::StaticMatrix{<:Any, <:Any, Ta},
+    b::StaticVector{<:Any, Tb}) where {Ta, Tb}
+    d = det(a)
+    T = typeof((one(Ta) * zero(Tb) + one(Ta) * zero(Tb)) / d)
+    @inbounds return similar_type(b, T)((a[2, 2] * b[1] - a[1, 2] * b[2]) / d,
+        (a[1, 1] * b[2] - a[2, 1] * b[1]) / d)
+end
+
+@inline function _linear_solve(::Size{(3, 3)},
+    ::Size{(3,)},
+    a::StaticMatrix{<:Any, <:Any, Ta},
+    b::StaticVector{<:Any, Tb}) where {Ta, Tb}
+    d = det(a)
+    T = typeof((one(Ta) * zero(Tb) + one(Ta) * zero(Tb)) / d)
+    @inbounds return similar_type(b, T)(((a[2, 2] * a[3, 3] - a[2, 3] * a[3, 2]) * b[1] +
+                                         (a[1, 3] * a[3, 2] - a[1, 2] * a[3, 3]) * b[2] +
+                                         (a[1, 2] * a[2, 3] - a[1, 3] * a[2, 2]) * b[3]) /
+                                        d,
+        ((a[2, 3] * a[3, 1] - a[2, 1] * a[3, 3]) * b[1] +
+         (a[1, 1] * a[3, 3] - a[1, 3] * a[3, 1]) * b[2] +
+         (a[1, 3] * a[2, 1] - a[1, 1] * a[2, 3]) * b[3]) / d,
+        ((a[2, 1] * a[3, 2] - a[2, 2] * a[3, 1]) * b[1] +
+         (a[1, 2] * a[3, 1] - a[1, 1] * a[3, 2]) * b[2] +
+         (a[1, 1] * a[2, 2] - a[1, 2] * a[2, 1]) * b[3]) / d)
+end
+
+for Sa in [(2, 2), (3, 3)]  # not needed for Sa = (1, 1);
+    @eval begin
+        @inline function _linear_solve(::Size{$Sa},
+            ::Size{Sb},
+            a::StaticMatrix{<:Any, <:Any, Ta},
+            b::StaticMatrix{<:Any, <:Any, Tb}) where {Sb, Ta, Tb}
+            d = det(a)
+            T = typeof((one(Ta) * zero(Tb) + one(Ta) * zero(Tb)) / d)
+            if isbitstype(T)
+                # This if block can be removed when https://github.com/JuliaArrays/StaticArrays.jl/pull/749 is merged.
+                c = similar(b, T)
+                for col in 1:Sb[2]
+                    @inbounds c[:, col] = _linear_solve(Size($Sa),
+                        Size($Sa[1]),
+                        a,
+                        b[:, col])
+                end
+                return similar_type(b, T)(c)
+            else
+                return _linear_solve_general($(Size(Sa)), Size(Sb), a, b)
+            end
+        end
+    end # @eval
+end
+
+@inline function _linear_solve(sa::Size, sb::Size, a::StaticMatrix, b::StaticVecOrMat)
+    _linear_solve_general(sa, sb, a, b)
+end
+
+@generated function _linear_solve_general(::Size{Sa},
+    ::Size{Sb},
+    a::StaticMatrix{<:Any, <:Any, Ta},
+    b::StaticVecOrMat{Tb}) where {Sa, Sb, Ta, Tb}
+    if Sa[1] != Sb[1]
+        return quote
+            throw(DimensionMismatch("Left and right hand side first dimensions do not match in backdivide (got sizes $Sa and $Sb)"))
+        end
+    end
+    quote
+        @_inline_meta
+        LUp = static_lu(a)
+        LUp.U \ (LUp.L \ $(length(Sb) > 1 ? :(b[LUp.p, :]) : :(b[LUp.p])))
+    end
+end

--- a/src/linalg/lu.jl
+++ b/src/linalg/lu.jl
@@ -1,0 +1,160 @@
+
+#Credits: StaticArrays.jl
+# https://github.com/JuliaArrays/StaticArrays.jl/blob/master/src/lu.jl
+
+# LU decomposition
+pivot_options = if isdefined(LinearAlgebra, :PivotingStrategy) # introduced in Julia v1.7
+    (:(Val{true}), :(Val{false}), :NoPivot, :RowMaximum)
+else
+    (:(Val{true}), :(Val{false}))
+end
+for pv in pivot_options
+    # ... define each `pivot::Val{true/false}` method individually to avoid ambiguties
+    @eval function static_lu(A::StaticLUMatrix, pivot::$pv; check = true)
+        L, U, p = _lu(A, pivot, check)
+        LU(L, U, p)
+    end
+
+    # For the square version, return explicit lower and upper triangular matrices.
+    # We would do this for the rectangular case too, but Base doesn't support that.
+    @eval function static_lu(A::StaticLUMatrix{N, N}, pivot::$pv; check = true) where {N}
+        L, U, p = _lu(A, pivot, check)
+        LU(LowerTriangular(L), UpperTriangular(U), p)
+    end
+end
+static_lu(A::StaticLUMatrix; check = true) = static_lu(A, Val(true); check = check)
+
+# location of the first zero on the diagonal, 0 when not found
+function _first_zero_on_diagonal(A::StaticLUMatrix{M, N, T}) where {M, N, T}
+    if @generated
+        quote
+            $(map(i -> :(A[$i, $i] == zero(T) && return $i), 1:min(M, N))...)
+            0
+        end
+    else
+        for i in 1:min(M, N)
+            A[i, i] == 0 && return i
+        end
+        0
+    end
+end
+
+@generated function _lu(A::StaticLUMatrix{M, N, T}, pivot, check) where {M, N, T}
+    _pivot = if isdefined(LinearAlgebra, :PivotingStrategy) # v1.7 feature
+        pivot === RowMaximum ? Val(true) : pivot === NoPivot ? Val(false) : pivot()
+    else
+        pivot()
+    end
+    quote
+        L, U, P = __lu(A, $(_pivot))
+        if check
+            i = _first_zero_on_diagonal(U)
+            i == 0 || throw(SingularException(i))
+        end
+        L, U, P
+    end
+end
+
+function __lu(A::StaticMatrix{0, 0, T}, ::Val{Pivot}) where {T, Pivot}
+    (SMatrix{0, 0, typeof(one(T))}(), A, SVector{0, Int}())
+end
+
+function __lu(A::StaticMatrix{0, 1, T}, ::Val{Pivot}) where {T, Pivot}
+    (SMatrix{0, 0, typeof(one(T))}(), A, SVector{0, Int}())
+end
+
+function __lu(A::StaticMatrix{0, N, T}, ::Val{Pivot}) where {T, N, Pivot}
+    (SMatrix{0, 0, typeof(one(T))}(), A, SVector{0, Int}())
+end
+
+function __lu(A::StaticMatrix{1, 0, T}, ::Val{Pivot}) where {T, Pivot}
+    (SMatrix{1, 0, typeof(one(T))}(), SMatrix{0, 0, T}(), SVector{1, Int}(1))
+end
+
+function __lu(A::StaticMatrix{M, 0, T}, ::Val{Pivot}) where {T, M, Pivot}
+    (SMatrix{M, 0, typeof(one(T))}(), SMatrix{0, 0, T}(), SVector{M, Int}(1:M))
+end
+
+function __lu(A::StaticMatrix{1, 1, T}, ::Val{Pivot}) where {T, Pivot}
+    (SMatrix{1, 1}(one(T)), A, SVector(1))
+end
+
+function __lu(A::LinearAlgebra.HermOrSym{T, <:StaticMatrix{1, 1, T}},
+    ::Val{Pivot}) where {T, Pivot}
+    (SMatrix{1, 1}(one(T)), A.data, SVector(1))
+end
+
+function __lu(A::StaticMatrix{1, N, T}, ::Val{Pivot}) where {N, T, Pivot}
+    (SMatrix{1, 1, T}(one(T)), A, SVector{1, Int}(1))
+end
+
+function __lu(A::StaticMatrix{M, 1}, ::Val{Pivot}) where {M, Pivot}
+    @inbounds begin
+        kp = 1
+        if Pivot
+            amax = abs(A[1, 1])
+            for i in 2:M
+                absi = abs(A[i, 1])
+                if absi > amax
+                    kp = i
+                    amax = absi
+                end
+            end
+        end
+        ps = tailindices(Val{M})
+        if kp != 1
+            ps = setindex(ps, 1, kp - 1)
+        end
+        U = SMatrix{1, 1}(A[kp, 1])
+        # Scale first column
+        Akkinv = inv(A[kp, 1])
+        Ls = A[ps, 1] * Akkinv
+        if !isfinite(Akkinv)
+            Ls = zeros(typeof(Ls))
+        end
+        L = [SVector{1}(one(eltype(Ls))); Ls]
+        p = [SVector{1, Int}(kp); ps]
+    end
+    return (SMatrix{M, 1}(L), U, p)
+end
+
+function __lu(A::StaticLUMatrix{M, N, T}, ::Val{Pivot}) where {M, N, T, Pivot}
+    @inbounds begin
+        kp = 1
+        if Pivot
+            amax = abs(A[1, 1])
+            for i in 2:M
+                absi = abs(A[i, 1])
+                if absi > amax
+                    kp = i
+                    amax = absi
+                end
+            end
+        end
+        ps = tailindices(Val{M})
+        if kp != 1
+            ps = setindex(ps, 1, kp - 1)
+        end
+        Ufirst = SMatrix{1, N}(A[kp, :])
+        # Scale first column
+        Akkinv = inv(A[kp, 1])
+        Ls = A[ps, 1] * Akkinv
+        if !isfinite(Akkinv)
+            Ls = zeros(typeof(Ls))
+        end
+
+        # Update the rest
+        Arest = A[ps, tailindices(Val{N})] - Ls * Ufirst[:, tailindices(Val{N})]
+        Lrest, Urest, prest = __lu(Arest, Val(Pivot))
+        p = [SVector{1, Int}(kp); ps[prest]]
+        L = [[SVector{1}(one(eltype(Ls))); Ls[prest]] [zeros(typeof(SMatrix{1}(Lrest[1,
+            :])));
+            Lrest]]
+        U = [Ufirst; [zeros(typeof(Urest[:, 1])) Urest]]
+    end
+    return (L, U, p)
+end
+
+@generated function tailindices(::Type{Val{M}}) where {M}
+    :(SVector{$(M - 1), Int}($(tuple(2:M...))))
+end

--- a/src/nlsolve/utils.jl
+++ b/src/nlsolve/utils.jl
@@ -14,7 +14,7 @@
         W_eval = nlsolver.W(tmp + γ * z_i, p, t + c * dt)
         f_eval = integrator.f(tmp + γ * z_i, p, t + c * dt)
         f_rhs = dt * f_eval - z_i
-        Δz = W_eval \ f_rhs
+        Δz = linear_solve(W_eval, f_rhs)
         z_i = z_i - Δz
 
         if norm(dt * integrator.f(tmp + γ * z_i, p, t + c * dt) - z_i) < abstol

--- a/src/perform_step/gpu_kvaerno3_perform_step.jl
+++ b/src/perform_step/gpu_kvaerno3_perform_step.jl
@@ -164,7 +164,8 @@ end
 
         W_eval = nlsolver.W(nlsolver.tmp + nlsolver.γ * z₄, p, t + nlsolver.c * dt)
 
-        err = W_eval \ (btilde1 * z₁ + btilde2 * z₂ + btilde3 * z₃ + btilde4 * z₄)
+        err = linear_solve(W_eval,
+            btilde1 * z₁ + btilde2 * z₂ + btilde3 * z₃ + btilde4 * z₄)
 
         tmp = (err) ./
               (abstol .+ max.(abs.(uprev), abs.(u)) * reltol)

--- a/src/perform_step/gpu_kvaerno5_perform_step.jl
+++ b/src/perform_step/gpu_kvaerno5_perform_step.jl
@@ -231,8 +231,9 @@ end
 
         W_eval = nlsolver.W(nlsolver.tmp + nlsolver.γ * z₇, p, t + nlsolver.c * dt)
 
-        err = (btilde1 * z₁ + btilde3 * z₃ + btilde4 * z₄ + btilde5 * z₅ + btilde6 * z₆ +
-               btilde7 * z₇)
+        err = linear_solve(W_eval,
+            btilde1 * z₁ + btilde3 * z₃ + btilde4 * z₄ + btilde5 * z₅ + btilde6 * z₆ +
+            btilde7 * z₇)
 
         tmp = (err) ./
               (abstol .+ max.(abs.(uprev), abs.(u)) * reltol)

--- a/src/perform_step/gpu_rodas4_perform_step.jl
+++ b/src/perform_step/gpu_rodas4_perform_step.jl
@@ -68,37 +68,37 @@
 
     # Step 1
     linsolve_tmp = du + dtd1 * dT
-    k1 = W \ -linsolve_tmp
+    k1 = linear_solve(W, -linsolve_tmp)
     u = uprev + a21 * k1
     du = f(u, p, t + c2 * dt)
 
     # Step 2
     linsolve_tmp = du + dtd2 * dT + dtC21 * k1
-    k2 = W \ -linsolve_tmp
+    k2 = linear_solve(W, -linsolve_tmp)
     u = uprev + a31 * k1 + a32 * k2
     du = f(u, p, t + c3 * dt)
 
     # Step 3
     linsolve_tmp = du + dtd3 * dT + (dtC31 * k1 + dtC32 * k2)
-    k3 = W \ -linsolve_tmp
+    k3 = linear_solve(W, -linsolve_tmp)
     u = uprev + a41 * k1 + a42 * k2 + a43 * k3
     du = f(u, p, t + c4 * dt)
 
     # Step 4
     linsolve_tmp = du + dtd4 * dT + (dtC41 * k1 + dtC42 * k2 + dtC43 * k3)
-    k4 = W \ -linsolve_tmp
+    k4 = linear_solve(W, -linsolve_tmp)
     u = uprev + a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4
     du = f(u, p, t + dt)
 
     # Step 5
     linsolve_tmp = du + (dtC52 * k2 + dtC54 * k4 + dtC51 * k1 + dtC53 * k3)
-    k5 = W \ -linsolve_tmp
+    k5 = linear_solve(W, -linsolve_tmp)
     u = u + k5
     du = f(u, p, t + dt)
 
     # Step 6
     linsolve_tmp = du + (dtC61 * k1 + dtC62 * k2 + dtC65 * k5 + dtC64 * k4 + dtC63 * k3)
-    k6 = W \ -linsolve_tmp
+    k6 = linear_solve(W, -linsolve_tmp)
     integ.u = u + k6
 
     @inbounds begin # Necessary for interpolation
@@ -185,37 +185,37 @@ end
 
         # Step 1
         linsolve_tmp = du + dtd1 * dT
-        k1 = W \ -linsolve_tmp
+        k1 = linear_solve(W, -linsolve_tmp)
         u = uprev + a21 * k1
         du = f(u, p, t + c2 * dt)
 
         # Step 2
         linsolve_tmp = du + dtd2 * dT + dtC21 * k1
-        k2 = W \ -linsolve_tmp
+        k2 = linear_solve(W, -linsolve_tmp)
         u = uprev + a31 * k1 + a32 * k2
         du = f(u, p, t + c3 * dt)
 
         # Step 3
         linsolve_tmp = du + dtd3 * dT + (dtC31 * k1 + dtC32 * k2)
-        k3 = W \ -linsolve_tmp
+        k3 = linear_solve(W, -linsolve_tmp)
         u = uprev + a41 * k1 + a42 * k2 + a43 * k3
         du = f(u, p, t + c4 * dt)
 
         # Step 4
         linsolve_tmp = du + dtd4 * dT + (dtC41 * k1 + dtC42 * k2 + dtC43 * k3)
-        k4 = W \ -linsolve_tmp
+        k4 = linear_solve(W, -linsolve_tmp)
         u = uprev + a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4
         du = f(u, p, t + dt)
 
         # Step 5
         linsolve_tmp = du + (dtC52 * k2 + dtC54 * k4 + dtC51 * k1 + dtC53 * k3)
-        k5 = W \ -linsolve_tmp
+        k5 = linear_solve(W, -linsolve_tmp)
         u = u + k5
         du = f(u, p, t + dt)
 
         # Step 6
         linsolve_tmp = du + (dtC61 * k1 + dtC62 * k2 + dtC65 * k5 + dtC64 * k4 + dtC63 * k3)
-        k6 = W \ -linsolve_tmp
+        k6 = linear_solve(W, -linsolve_tmp)
         u = u + k6
 
         tmp = k6 ./ (abstol .+ max.(abs.(uprev), abs.(u)) * reltol)

--- a/src/perform_step/gpu_rodas5P_perform_step.jl
+++ b/src/perform_step/gpu_rodas5P_perform_step.jl
@@ -82,51 +82,51 @@
 
     # Step 1
     linsolve_tmp = du + dtd1 * dT
-    k1 = W \ -linsolve_tmp
+    k1 = linear_solve(W, -linsolve_tmp)
     u = uprev + a21 * k1
     du = f(u, p, t + c2 * dt)
 
     # Step 2
     linsolve_tmp = du + dtd2 * dT + dtC21 * k1
-    k2 = W \ -linsolve_tmp
+    k2 = linear_solve(W, -linsolve_tmp)
     u = uprev + a31 * k1 + a32 * k2
     du = f(u, p, t + c3 * dt)
 
     # Step 3
     linsolve_tmp = du + dtd3 * dT + (dtC31 * k1 + dtC32 * k2)
-    k3 = W \ -linsolve_tmp
+    k3 = linear_solve(W, -linsolve_tmp)
     u = uprev + a41 * k1 + a42 * k2 + a43 * k3
     du = f(u, p, t + c4 * dt)
 
     # Step 4
     linsolve_tmp = du + dtd4 * dT + (dtC41 * k1 + dtC42 * k2 + dtC43 * k3)
-    k4 = W \ -linsolve_tmp
+    k4 = linear_solve(W, -linsolve_tmp)
     u = uprev + a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4
     du = f(u, p, t + c5 * dt)
 
     # Step 5
     linsolve_tmp = du + dtd5 * dT + (dtC52 * k2 + dtC54 * k4 + dtC51 * k1 + dtC53 * k3)
-    k5 = W \ -linsolve_tmp
+    k5 = linear_solve(W, -linsolve_tmp)
     u = uprev + a61 * k1 + a62 * k2 + a63 * k3 + a64 * k4 + a65 * k5
     du = f(u, p, t + dt)
 
     # Step 6
     linsolve_tmp = du + (dtC61 * k1 + dtC62 * k2 + dtC63 * k3 + dtC64 * k4 + dtC65 * k5)
-    k6 = W \ -linsolve_tmp
+    k6 = linear_solve(W, -linsolve_tmp)
     u = u + k6
     du = f(u, p, t + dt)
 
     # Step 7
     linsolve_tmp = du + (dtC71 * k1 + dtC72 * k2 + dtC73 * k3 + dtC74 * k4 + dtC75 * k5 +
                     dtC76 * k6)
-    k7 = W \ -linsolve_tmp
+    k7 = linear_solve(W, -linsolve_tmp)
     u = u + k7
     du = f(u, p, t + dt)
 
     # Step 8
     linsolve_tmp = du + (dtC81 * k1 + dtC82 * k2 + dtC83 * k3 + dtC84 * k4 + dtC85 * k5 +
                     dtC86 * k6 + dtC87 * k7)
-    k8 = W \ -linsolve_tmp
+    k8 = linear_solve(W, -linsolve_tmp)
     integ.u = u + k8
 
     @inbounds begin # Necessary for interpolation
@@ -230,37 +230,37 @@ end
 
         # Step 1
         linsolve_tmp = du + dtd1 * dT
-        k1 = W \ -linsolve_tmp
+        k1 = linear_solve(W, -linsolve_tmp)
         u = uprev + a21 * k1
         du = f(u, p, t + c2 * dt)
 
         # Step 2
         linsolve_tmp = du + dtd2 * dT + dtC21 * k1
-        k2 = W \ -linsolve_tmp
+        k2 = linear_solve(W, -linsolve_tmp)
         u = uprev + a31 * k1 + a32 * k2
         du = f(u, p, t + c3 * dt)
 
         # Step 3
         linsolve_tmp = du + dtd3 * dT + (dtC31 * k1 + dtC32 * k2)
-        k3 = W \ -linsolve_tmp
+        k3 = linear_solve(W, -linsolve_tmp)
         u = uprev + a41 * k1 + a42 * k2 + a43 * k3
         du = f(u, p, t + c4 * dt)
 
         # Step 4
         linsolve_tmp = du + dtd4 * dT + (dtC41 * k1 + dtC42 * k2 + dtC43 * k3)
-        k4 = W \ -linsolve_tmp
+        k4 = linear_solve(W, -linsolve_tmp)
         u = uprev + a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4
         du = f(u, p, t + c5 * dt)
 
         # Step 5
         linsolve_tmp = du + dtd5 * dT + (dtC52 * k2 + dtC54 * k4 + dtC51 * k1 + dtC53 * k3)
-        k5 = W \ -linsolve_tmp
+        k5 = linear_solve(W, -linsolve_tmp)
         u = uprev + a61 * k1 + a62 * k2 + a63 * k3 + a64 * k4 + a65 * k5
         du = f(u, p, t + dt)
 
         # Step 6
         linsolve_tmp = du + (dtC61 * k1 + dtC62 * k2 + dtC63 * k3 + dtC64 * k4 + dtC65 * k5)
-        k6 = W \ -linsolve_tmp
+        k6 = linear_solve(W, -linsolve_tmp)
         u = u + k6
         du = f(u, p, t + dt)
 
@@ -268,7 +268,7 @@ end
         linsolve_tmp = du +
                        (dtC71 * k1 + dtC72 * k2 + dtC73 * k3 + dtC74 * k4 + dtC75 * k5 +
                         dtC76 * k6)
-        k7 = W \ -linsolve_tmp
+        k7 = linear_solve(W, -linsolve_tmp)
         u = u + k7
         du = f(u, p, t + dt)
 
@@ -276,7 +276,7 @@ end
         linsolve_tmp = du +
                        (dtC81 * k1 + dtC82 * k2 + dtC83 * k3 + dtC84 * k4 + dtC85 * k5 +
                         dtC86 * k6 + dtC87 * k7)
-        k8 = W \ -linsolve_tmp
+        k8 = linear_solve(W, -linsolve_tmp)
         u = u + k8
 
         tmp = k8 ./ (abstol .+ max.(abs.(uprev), abs.(u)) * reltol)

--- a/src/perform_step/gpu_rosenbrock23_perform_step.jl
+++ b/src/perform_step/gpu_rosenbrock23_perform_step.jl
@@ -52,9 +52,9 @@
     F₁ = f(uprev + dto2 * k1, p, t + dto2)
 
     if mass_matrix === I
-        k2 = linear_solve(W_fact, (F₁ - k1) + k1)
+        k2 = linear_solve(W_fact, (F₁ - k1)) + k1
     else
-        k2 = linear_solve(W_fact, (F₁ - mass_matrix * k1) + k1)
+        k2 = linear_solve(W_fact, (F₁ - mass_matrix * k1)) + k1
     end
 
     integ.u = uprev + dt * k2
@@ -124,9 +124,9 @@ end
         F₁ = f(uprev + dto2 * k1, p, t + dto2)
 
         if mass_matrix === I
-            k2 = linear_solve(W_fact, (F₁ - k1) + k1)
+            k2 = linear_solve(W_fact, F₁ - k1) + k1
         else
-            k2 = linear_solve(W_fact, (F₁ - mass_matrix * k1) + k1)
+            k2 = linear_solve(W_fact, F₁ - mass_matrix * k1) + k1
         end
 
         u = uprev + dt * k2

--- a/src/perform_step/gpu_rosenbrock23_perform_step.jl
+++ b/src/perform_step/gpu_rosenbrock23_perform_step.jl
@@ -47,14 +47,14 @@
 
     # F = lu(W)
     F₀ = f(uprev, p, t)
-    k1 = W_fact \ (F₀ + γ * dT)
+    k1 = linear_solve(W_fact, F₀ + γ * dT)
 
     F₁ = f(uprev + dto2 * k1, p, t + dto2)
 
     if mass_matrix === I
-        k2 = W_fact \ (F₁ - k1) + k1
+        k2 = linear_solve(W_fact, (F₁ - k1) + k1)
     else
-        k2 = W_fact \ (F₁ - mass_matrix * k1) + k1
+        k2 = linear_solve(W_fact, (F₁ - mass_matrix * k1) + k1)
     end
 
     integ.u = uprev + dt * k2
@@ -119,14 +119,14 @@ end
 
         # F = lu(W)
         F₀ = f(uprev, p, t)
-        k1 = W_fact \ (F₀ + γ * dT)
+        k1 = linear_solve(W_fact, F₀ + γ * dT)
 
         F₁ = f(uprev + dto2 * k1, p, t + dto2)
 
         if mass_matrix === I
-            k2 = W_fact \ (F₁ - k1) + k1
+            k2 = linear_solve(W_fact, (F₁ - k1) + k1)
         else
-            k2 = W_fact \ (F₁ - mass_matrix * k1) + k1
+            k2 = linear_solve(W_fact, (F₁ - mass_matrix * k1) + k1)
         end
 
         u = uprev + dt * k2
@@ -135,11 +135,12 @@ end
         F₂ = f(u, p, t + dt)
 
         if mass_matrix === I
-            k3 = W_fact \ (F₂ - e32 * (k2 - F₁) - 2 * (k1 - F₀) + dt * dT)
+            k3 = linear_solve(W_fact, F₂ - e32 * (k2 - F₁) - 2 * (k1 - F₀) + dt * dT)
 
         else
-            k3 = W_fact \ (F₂ - mass_matrix * (e32 * k2 + 2 * k1) +
-                  e32 * F₁ + 2 * F₀ + dt * dT)
+            k3 = linear_solve(W_fact,
+                F₂ - mass_matrix * (e32 * k2 + 2 * k1) +
+                e32 * F₁ + 2 * F₀ + dt * dT)
         end
 
         tmp = dto6 * (k1 - 2 * k2 + k3)

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
@@ -25,7 +25,7 @@ function f_large(u::AbstractArray{T}, p, t) where {T}
     return T(1.01) * u
 end
 
-large_u0 = @SVector rand(Float32, 20)
+large_u0 = @SVector rand(Float32, 15)
 large_prob = ODEProblem(f_large, large_u0, (0.0f0, 10.0f0))
 
 algs = (GPURosenbrock23(), GPURodas4(), GPURodas5P(), GPUKvaerno3(), GPUKvaerno5())
@@ -132,6 +132,6 @@ for alg in algs
     ## large no. of dimensions
     monteprob = EnsembleProblem(large_prob, safetycopy = false)
 
-    local sol = solve(monteprob, alg, EnsembleGPUKernel(backend, 0.0), trajectories = 10,
+    local sol = solve(monteprob, alg, EnsembleGPUKernel(backend, 0.0), trajectories = 2,
         adaptive = true, dt = 0.1f0)
 end

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
@@ -25,7 +25,8 @@ function f_large(u::AbstractArray{T}, p, t) where {T}
     return T(1.01) * u
 end
 
-large_prob = ODEProblem(f_large, @SVector rand(Float32, 20), (0.0f0, 10.0f0))
+large_u0 = @SVector rand(Float32, 20)
+large_prob = ODEProblem(f_large, large_u0, (0.0f0, 10.0f0))
 
 algs = (GPURosenbrock23(), GPURodas4(), GPURodas5P(), GPUKvaerno3(), GPUKvaerno5())
 for alg in algs

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
@@ -130,8 +130,11 @@ for alg in algs
         adaptive = true, dt = 0.1f-1, abstol = 1.0f-7, reltol = 1.0f-7)
 
     ## large no. of dimensions
-    monteprob = EnsembleProblem(large_prob, safetycopy = false)
 
-    local sol = solve(monteprob, alg, EnsembleGPUKernel(backend, 0.0), trajectories = 2,
-        adaptive = true, dt = 0.1f0)
+    if GROUP == "CUDA"
+        monteprob = EnsembleProblem(large_prob, safetycopy = false)
+
+        local sol = solve(monteprob, alg, EnsembleGPUKernel(backend, 0.0), trajectories = 2,
+            adaptive = true, dt = 0.1f0)
+    end
 end


### PR DESCRIPTION
The PR allows us to solve relatively larger state parameter-parallel models. It is made possible by removing the constraint in StaticArrays.jl, which forces to allocate when size > 14. The problem is mainly in the Linear Algebra routines such as `lu` and `\` .