### PR TITLE
Start implementation of kernels compatible with out-of-place problems

### DIFF
--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -883,6 +883,16 @@ function vectorized_map_solve(probs, alg,
         adaptive = adaptive, kwargs...)
 end
 
+function handle_iip_prob(prob)
+    if DiffEqBase.isinplace(prob)
+        remake(prob;
+            u0 = convert(SArray, prob.u0),
+            p = prob.p isa SciMLBase.NullParameters ? prob.p : convert(SArray, prob.p))
+    else
+        prob
+    end
+end
+
 function batch_solve(ensembleprob, alg,
     ensemblealg::Union{EnsembleArrayAlgorithm, EnsembleKernelAlgorithm}, I,
     adaptive;
@@ -926,6 +936,7 @@ function batch_solve(ensembleprob, alg,
             # Get inner saveat if global one isn't specified
             _saveat = get(probs[1].kwargs, :saveat, nothing)
             saveat = _saveat === nothing ? get(kwargs, :saveat, nothing) : _saveat
+            # probs = handle_iip_prob.(probs)
             solts, solus = batch_solve_up_kernel(ensembleprob, probs, alg, ensemblealg, I,
                 adaptive; saveat = saveat, kwargs...)
             [begin

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -26,8 +26,8 @@ end
     if saveat === nothing && save_everystep
         saved = true
         savedexactly = true
-        @inbounds us[integrator.step_idx] = integrator.u
-        @inbounds ts[integrator.step_idx] = integrator.t
+        @inbounds us[integrator.step_idx] = convert(eltype(us), integrator.u)
+        @inbounds ts[integrator.step_idx] = convert(eltype(ts), integrator.t)
         integrator.step_idx += 1
     elseif saveat !== nothing
         saved = true
@@ -35,9 +35,10 @@ end
         while integrator.cur_t <= length(saveat) && saveat[integrator.cur_t] <= integrator.t
             savet = saveat[integrator.cur_t]
             Θ = (savet - integrator.tprev) / integrator.dt
-            @inbounds us[integrator.cur_t] = _ode_interpolant(Θ, integrator.dt,
-                integrator.uprev, integrator)
-            @inbounds ts[integrator.cur_t] = savet
+            @inbounds us[integrator.cur_t] = convert(eltype(us),
+                _ode_interpolant(Θ, integrator.dt,
+                    integrator.uprev, integrator))
+            @inbounds ts[integrator.cur_t] = convert(eltype(ts), savet)
             integrator.cur_t += 1
         end
     end

--- a/src/integrators/types.jl
+++ b/src/integrators/types.jl
@@ -318,7 +318,6 @@ end
     TS, CB, ST}
     cs, as, rs = SimpleDiffEq._build_tsit5_caches(T)
 
-    !IIP && @assert S <: SArray
     event_last_time = 1
     vector_event_last_time = 0
     last_event_error = zero(T)
@@ -347,7 +346,7 @@ end
     saveat::ST) where {F, P, S, T, N, TOL, TS, CB, ST}
     cs, as, btildes, rs = SimpleDiffEq._build_atsit5_caches(T)
 
-    !IIP && @assert S <: SArray
+    @assert S <: SArray
 
     qoldinit = T(1e-4)
     event_last_time = 1


### PR DESCRIPTION
MWE:
```julia
using DiffEqGPU, DiffEqBase, StaticArrays

function lorenz!(du,u,p,t)
 du[1] = 10.0(u[2]-u[1])
 du[2] = u[1]*(28.0-u[3]) - u[2]
 du[3] = u[1]*u[2] - (8/3)*u[3]
end
u0 = @SArray [1.0;0.0;0.0]
tspan = (0.0,100.0)
prob = ODEProblem(lorenz!,u0,tspan)

ensembleProb = EnsembleProblem(prob)

using CUDA

sol = solve(ensembleProb, GPUTsit5(), EnsembleGPUKernel(CUDABackend()), dt = 0.01, adaptive = false, trajectories = 2)
```
Current issue:

Tries to dynamically allocate. Hence, it fails for high number of trajectories. Similar to https://github.com/SciML/DiffEqGPU.jl/issues/219

