### PR TITLE
Revert SciMLBase v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqGPU"
 uuid = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 authors = ["Chris Rackauckas", "SciML"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -52,7 +52,7 @@ MuladdMacro = "0.2"
 Parameters = "0.12"
 RecursiveArrayTools = "2"
 Requires = "1.0"
-SciMLBase = "1.26, 2"
+SciMLBase = "1.26"
 Setfield = "1"
 SimpleDiffEq = "1"
 StaticArrays = "1"


### PR DESCRIPTION
Causes issue with GPU solvers as the mutable structs does not allow compilation of the GPU solvers