### PR TITLE
[ci skip] Fix spelling errors

### DIFF
--- a/docs/src/tutorials/lower_level_api.md
+++ b/docs/src/tutorials/lower_level_api.md
@@ -57,7 +57,7 @@ probs = cu(probs)
 Note that the core is the function `DiffEqGPU.vectorized_solve` which is the solver for the CUDA-based `probs`
 which uses the manually converted problems, and returns `us` which is a vector of CuArrays for the solution.
 
-Similarily, there exists a lower-level API for `EnsembleGPUArray` as well, primarily for benchmarking purposes. The solution
+Similarly, there exists a lower-level API for `EnsembleGPUArray` as well, primarily for benchmarking purposes. The solution
 returned for state (`sol.u`) is a matrix having columns as different parameter-parallel solutions for the ensemble problem.
 An example is shown below:
 

--- a/docs/src/tutorials/weak_order_conv_sde.md
+++ b/docs/src/tutorials/weak_order_conv_sde.md
@@ -37,5 +37,5 @@ using Plots
 plot(ts, us_expect, lw = 5,
     xaxis = "Time (t)", yaxis = "y(t)", label = "True Expected value")
 
-plot!(ts, us_calc, lw = 3, ls = :dash, label = "Caculated Expected value")
+plot!(ts, us_calc, lw = 3, ls = :dash, label = "Calculated Expected value")
 ```

--- a/src/ensemblegpukernel/integrators/integrator_utils.jl
+++ b/src/ensemblegpukernel/integrators/integrator_utils.jl
@@ -278,7 +278,7 @@ end
         callback::DiffEqGPU.GPUContinuousCallback,
         counter) where {AlgType <: GPUODEAlgorithm,
         IIP, S, T}
-    event_occurred, interp_index, prev_sign, prev_sign_index, event_idx = DiffEqBase.determine_event_occurance(
+    event_occurred, interp_index, prev_sign, prev_sign_index, event_idx = DiffEqBase.determine_event_occurrence(
         integrator,
         callback,
         counter)
@@ -360,7 +360,7 @@ end
 end
 
 # interp_points = 0 or equivalently nothing
-@inline function DiffEqBase.determine_event_occurance(
+@inline function DiffEqBase.determine_event_occurrence(
         integrator::DiffEqBase.AbstractODEIntegrator{
             AlgType,
             IIP,

--- a/src/ensemblegpukernel/kernels.jl
+++ b/src/ensemblegpukernel/kernels.jl
@@ -40,7 +40,7 @@
         !saved_in_cb && savevalues!(integ, ts, us)
     end
     if integ.t > tspan[2] && saveat === nothing
-        ## Intepolate to tf
+        ## Interpolate to tf
         @inbounds us[end] = integ(tspan[2])
         @inbounds ts[end] = tspan[2]
     end
@@ -99,7 +99,7 @@ end
     end
 
     if integ.t > tspan[2] && saveat === nothing
-        ## Intepolate to tf
+        ## Interpolate to tf
         @inbounds us[end] = integ(tspan[2])
         @inbounds ts[end] = tspan[2]
     end


### PR DESCRIPTION
## Summary

This PR fixes clear spelling errors found in the codebase.

## Changes Made

- Intepolate -> Interpolate
- Similarily -> Similarly
- Caculated -> Calculated
- occurance -> occurrence

## Notes

-  included to avoid unnecessary CI runs for spelling fixes
- Only fixed clear spelling errors, preserved technical terms
- Changes are in comments/documentation and don't affect functionality