### PR TITLE
Fix Julia 1.11 AbstractVectorOfArray indexing deprecation warnings

### DIFF
--- a/test/distributed_multi_gpu.jl
+++ b/test/distributed_multi_gpu.jl
@@ -34,8 +34,8 @@ monteprob = EnsembleProblem(prob, prob_func = prob_func_distributed)
 
 @test length(filter(x -> x.u != sol.u[1].u, sol.u)) != 0 # 0 element array
 @test length(filter(x -> x.u != sol2.u[6].u, sol.u)) != 0 # 0 element array
-@test all(all(sol[i].prob.p .== pre_p_distributed[i] .* p) for i in 1:10)
-@test all(all(sol2[i].prob.p .== pre_p_distributed[i] .* p) for i in 1:10)
+@test all(all(sol.u[i].prob.p .== pre_p_distributed[i] .* p) for i in 1:10)
+@test all(all(sol2.u[i].prob.p .== pre_p_distributed[i] .* p) for i in 1:10)
 
 #To set 1 GPU per device:
 #=

--- a/test/ensemblegpuarray.jl
+++ b/test/ensemblegpuarray.jl
@@ -30,8 +30,8 @@ monteprob = EnsembleProblem(prob, prob_func = prob_func)
 
 @test length(filter(x -> x.u != sol.u[1].u, sol.u)) != 0 # 0 element array
 @test length(filter(x -> x.u != sol2.u[6].u, sol.u)) != 0 # 0 element array
-@test all(all(sol[i].prob.p .== pre_p[i] .* p) for i in 1:10)
-@test all(all(sol2[i].prob.p .== pre_p[i] .* p) for i in 1:10)
+@test all(all(sol.u[i].prob.p .== pre_p[i] .* p) for i in 1:10)
+@test all(all(sol2.u[i].prob.p .== pre_p[i] .* p) for i in 1:10)
 
 @time solve(monteprob, Tsit5(), EnsembleCPUArray(), trajectories = 10, saveat = 1.0f0)
 @time solve(monteprob, Tsit5(), EnsembleThreads(), trajectories = 10, saveat = 1.0f0)

--- a/test/gpu_kernel_de/finite_diff.jl
+++ b/test/gpu_kernel_de/finite_diff.jl
@@ -26,7 +26,7 @@ for alg in (GPURosenbrock23(autodiff = false), GPURodas4(autodiff = false),
     @info alg
     sol = solve(monteprob, alg, EnsembleGPUKernel(backend, 0.0),
         trajectories = 2, save_everystep = false, adaptive = true, dt = 0.01f0)
-    @test norm(sol[1].u - osol.u) < 2e-4
+    @test norm(sol.u[1].u - osol.u) < 2e-4
 
     # massive threads
     sol = solve(monteprob, alg, EnsembleGPUKernel(backend, 0.0),

--- a/test/gpu_kernel_de/gpu_ode_continuous_callbacks.jl
+++ b/test/gpu_kernel_de/gpu_ode_continuous_callbacks.jl
@@ -41,7 +41,7 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
     bench_sol = solve(prob, diffeq_alg,
         adaptive = false, dt = 0.1f0, callback = cb, merge_callbacks = true)
 
-    @test norm(bench_sol.u - sol[1].u) < 2e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-3
 
     @info "Callback: CallbackSets"
 
@@ -54,7 +54,7 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
     bench_sol = solve(prob, diffeq_alg,
         adaptive = false, dt = 0.1f0, callback = cb, merge_callbacks = true)
 
-    @test norm(bench_sol.u - sol[1].u) < 2e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-3
 
     @info "saveat and callbacks"
 
@@ -67,7 +67,7 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         saveat = [0.0f0, 9.1f0])
 
-    @test norm(bench_sol.u - sol[1].u) < 2e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-3
 
     @info "save_everystep and callbacks"
 
@@ -80,7 +80,7 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         adaptive = false, dt = 0.1f0, callback = cb, merge_callbacks = true,
         save_everystep = false)
 
-    @test norm(bench_sol.u - sol[1].u) < 7e-4
+    @test norm(bench_sol.u - sol.u[1].u) < 7e-4
 
     @info "Adaptive version"
 
@@ -94,7 +94,7 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         adaptive = true, save_everystep = false, dt = 0.1f0, callback = cb,
         merge_callbacks = true)
 
-    @test norm(bench_sol.u - sol[1].u) < 2e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-3
 
     @info "Callback: CallbackSets"
 
@@ -108,7 +108,7 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         adaptive = true, dt = 0.1f0, save_everystep = false, callback = cb,
         merge_callbacks = true)
 
-    @test norm(bench_sol.u - sol[1].u) < 2e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-3
 
     @info "saveat and callbacks"
 
@@ -123,7 +123,7 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         tstops = [24.0f0, 40.0f0], saveat = [0.0f0, 9.1f0], reltol = 1.0f-6,
         abstol = 1.0f-6)
 
-    @test norm(bench_sol.u - sol[1].u) < 8e-4
+    @test norm(bench_sol.u - sol.u[1].u) < 8e-4
 
     @info "Unadaptive and Adaptive comparison"
 
@@ -137,5 +137,5 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         adaptive = true, dt = 0.1f0, callback = cb, merge_callbacks = true,
         saveat = [0.0f0, 9.1f0])
 
-    @test norm(asol[1].u - sol[1].u) < 7e-4
+    @test norm(asol.u[1].u - sol.u[1].u) < 7e-4
 end

--- a/test/gpu_kernel_de/gpu_ode_discrete_callbacks.jl
+++ b/test/gpu_kernel_de/gpu_ode_discrete_callbacks.jl
@@ -34,8 +34,8 @@ for alg in algs
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         tstops = [2.40f0])
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 2e-3
-    @test norm(bench_sol.u - sol[1].u) < 5e-3
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 2e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 5e-3
 
     #Test the truncation error due to floating point math, encountered when adjusting t for tstops
     local sol = solve(monteprob, alg, EnsembleGPUKernel(backend),
@@ -47,8 +47,8 @@ for alg in algs
         adaptive = false, dt = 0.01f0, callback = cb, merge_callbacks = true,
         tstops = [4.0f0])
 
-    @test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 2e-6
-    @test norm(bench_sol.u - sol[1].u) < 3e-5
+    @test norm(bench_sol(4.0f0) - sol.u[1](4.0f0)) < 2e-6
+    @test norm(bench_sol.u - sol.u[1].u) < 3e-5
 
     @info "Callback: CallbackSets"
 
@@ -70,9 +70,9 @@ for alg in algs
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         tstops = [2.40f0, 4.0f0])
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 2e-3
-    @test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 3e-3
-    @test norm(bench_sol.u - sol[1].u) < 7e-3
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 2e-3
+    @test norm(bench_sol(4.0f0) - sol.u[1](4.0f0)) < 3e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 7e-3
 
     @info "saveat and callbacks"
 
@@ -85,9 +85,9 @@ for alg in algs
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         tstops = [2.40f0, 4.0f0], saveat = [0.0f0, 6.0f0])
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 1e-3
-    @test norm(bench_sol(6.0f0) - sol[1](6.0f0)) < 3e-3
-    @test norm(bench_sol.u - sol[1].u) < 3e-3
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 1e-3
+    @test norm(bench_sol(6.0f0) - sol.u[1](6.0f0)) < 3e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 3e-3
 
     @info "save_everystep and callbacks"
 
@@ -100,9 +100,9 @@ for alg in algs
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         tstops = [2.40f0, 4.0f0], save_everystep = false)
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 3e-5
-    @test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 5e-5
-    @test norm(bench_sol.u - sol[1].u) < 2e-4
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 3e-5
+    @test norm(bench_sol(4.0f0) - sol.u[1](4.0f0)) < 5e-5
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-4
 
     @info "Adaptive version"
 
@@ -118,8 +118,8 @@ for alg in algs
         merge_callbacks = true,
         tstops = [4.0f0])
 
-    @test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 5e-5
-    @test norm(bench_sol.u - sol[1].u) < 2e-4
+    @test norm(bench_sol(4.0f0) - sol.u[1](4.0f0)) < 5e-5
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-4
 
     @info "Callback: CallbackSets"
 
@@ -133,9 +133,9 @@ for alg in algs
         merge_callbacks = true,
         tstops = [2.40f0, 4.0f0])
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 6e-4
-    @test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 1e-3
-    @test norm(bench_sol.u - sol[1].u) < 3e-3
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 6e-4
+    @test norm(bench_sol(4.0f0) - sol.u[1](4.0f0)) < 1e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 3e-3
 
     @info "saveat and callbacks"
 
@@ -151,9 +151,9 @@ for alg in algs
         tstops = [2.40f0, 4.0f0], saveat = [0.0f0, 6.0f0], reltol = 1.0f-7,
         abstol = 1.0f-7)
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 7e-3
-    @test norm(bench_sol(6.0f0) - sol[1](6.0f0)) < 2e-2
-    @test norm(bench_sol.u - sol[1].u) < 2e-2
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 7e-3
+    @test norm(bench_sol(6.0f0) - sol.u[1](6.0f0)) < 2e-2
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-2
 
     @info "Unadaptive and Adaptive comparison"
 
@@ -167,9 +167,9 @@ for alg in algs
         adaptive = true, dt = 1.0f0, callback = cb, merge_callbacks = true,
         tstops = [2.40f0, 4.0f0], saveat = [0.0f0, 4.0f0])
 
-    @test norm(asol[1](2.40f0) - sol[1](2.40f0)) < 3e-3
-    @test norm(asol[1](4.0f0) - sol[1](4.0f0)) < 5e-3
-    @test norm(asol[1].u - sol[1].u) < 5e-3
+    @test norm(asol.u[1](2.40f0) - sol.u[1](2.40f0)) < 3e-3
+    @test norm(asol.u[1](4.0f0) - sol.u[1](4.0f0)) < 5e-3
+    @test norm(asol.u[1].u - sol.u[1].u) < 5e-3
 
     @info "Terminate callback"
 
@@ -184,6 +184,6 @@ for alg in algs
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         tstops = [2.40f0])
 
-    @test norm(bench_sol.t - sol[1].t) < 2e-3
-    @test norm(bench_sol.u - sol[1].u) < 5e-3
+    @test norm(bench_sol.t - sol.u[1].t) < 2e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 5e-3
 end

--- a/test/gpu_kernel_de/gpu_ode_regression.jl
+++ b/test/gpu_kernel_de/gpu_ode_regression.jl
@@ -36,8 +36,8 @@ for alg in algs
     bench_asol = solve(prob, Vern9(), dt = 0.1f-1, save_everystep = false, abstol = 1.0f-7,
         reltol = 1.0f-7)
 
-    @test norm(bench_sol.u[end] - sol[1].u[end]) < 5e-3
-    @test norm(bench_asol.u - asol[1].u) < 8e-4
+    @test norm(bench_sol.u[end] - sol.u[1].u[end]) < 5e-3
+    @test norm(bench_asol.u - asol.u[1].u) < 8e-4
 
     ### solve parameters
 
@@ -54,13 +54,13 @@ for alg in algs
     bench_asol = solve(prob, Vern9(), dt = 0.1f-1, save_everystep = false, abstol = 1.0f-7,
         reltol = 1.0f-7, saveat = saveat)
 
-    @test norm(asol[1].u[end] - sol[1].u[end]) < 5e-3
+    @test norm(asol.u[1].u[end] - sol.u[1].u[end]) < 5e-3
 
-    @test norm(bench_sol.u - sol[1].u) < 2e-4
-    @test norm(bench_asol.u - asol[1].u) < 2e-4
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-4
+    @test norm(bench_asol.u - asol.u[1].u) < 2e-4
 
-    @test length(sol[1].u) == length(saveat)
-    @test length(asol[1].u) == length(saveat)
+    @test length(sol.u[1].u) == length(saveat)
+    @test length(asol.u[1].u) == length(saveat)
 
     saveat = collect(0.0f0:0.1f0:10.0f0)
 
@@ -75,22 +75,22 @@ for alg in algs
     bench_asol = solve(prob, Vern9(), dt = 0.1f-1, save_everystep = false, abstol = 1.0f-7,
         reltol = 1.0f-7, saveat = saveat)
 
-    @test norm(asol[1].u[end] - sol[1].u[end]) < 6e-3
+    @test norm(asol.u[1].u[end] - sol.u[1].u[end]) < 6e-3
 
-    @test norm(bench_sol.u - sol[1].u) < 2e-3
-    @test norm(bench_asol.u - asol[1].u) < 5e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-3
+    @test norm(bench_asol.u - asol.u[1].u) < 5e-3
 
-    @test length(sol[1].u) == length(saveat)
-    @test length(asol[1].u) == length(saveat)
+    @test length(sol.u[1].u) == length(saveat)
+    @test length(asol.u[1].u) == length(saveat)
 
     local sol = solve(monteprob, alg, EnsembleGPUKernel(backend), trajectories = 2,
         adaptive = false, dt = 0.01f0, save_everystep = false)
 
     bench_sol = solve(prob, Vern9(), adaptive = false, dt = 0.01f0, save_everystep = false)
 
-    @test norm(bench_sol.u - sol[1].u) < 5e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 5e-3
 
-    @test length(sol[1].u) == length(bench_sol.u)
+    @test length(sol.u[1].u) == length(bench_sol.u)
 
     ### Huge number of threads
     local sol = solve(monteprob, alg, EnsembleGPUKernel(backend), trajectories = 10_000,

--- a/test/gpu_kernel_de/gpu_sde_convergence.jl
+++ b/test/gpu_kernel_de/gpu_sde_convergence.jl
@@ -14,7 +14,7 @@ prob = SDEProblem(f, g, u₀, tspan, p; seed = 1234)
 dts = 1 .// 2 .^ (5:-1:2)
 
 ensemble_prob = EnsembleProblem(prob;
-    output_func = (sol, i) -> (sol[end], false))
+    output_func = (sol, i) -> (sol.u[end], false))
 
 @info "EM"
 dts = 1 .// 2 .^ (12:-1:8)

--- a/test/gpu_kernel_de/gpu_sde_regression.jl
+++ b/test/gpu_kernel_de/gpu_sde_regression.jl
@@ -33,7 +33,7 @@ for alg in algs
 
     us = reshape(mean(sol_array, dims = 3), size(sol_array, 2))
 
-    us_exact = 0.5f0 * exp.(sol[1].t)
+    us_exact = 0.5f0 * exp.(sol.u[1].t)
 
     @test norm(us - us_exact, Inf) < 6e-2
 
@@ -67,7 +67,7 @@ for alg in algs
         adaptive = false, save_everystep = false)
 
     @test sol.converged == true
-    @test length(sol[1].u) == 2
+    @test length(sol.u[1].u) == 2
 
     saveat = [0.3f0, 0.5f0]
 
@@ -111,4 +111,4 @@ sol = solve(
     adaptive = false, save_everystep = false)
 
 @test sol.converged == true
-@test length(sol[1].u) == 2
+@test length(sol.u[1].u) == 2

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_continuous_callbacks.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_continuous_callbacks.jl
@@ -54,7 +54,7 @@ for alg in algs
     bench_sol = solve(prob, Rosenbrock23(),
         adaptive = false, dt = 0.1f0, callback = cb, merge_callbacks = true)
 
-    @test norm(bench_sol.u - sol[1].u) < 8e-4
+    @test norm(bench_sol.u - sol.u[1].u) < 8e-4
 
     @info "Callback: CallbackSets"
 
@@ -67,7 +67,7 @@ for alg in algs
     bench_sol = solve(prob, Rosenbrock23(),
         adaptive = false, dt = 0.1f0, callback = cb, merge_callbacks = true)
 
-    @test norm(bench_sol.u - sol[1].u) < 8e-4
+    @test norm(bench_sol.u - sol.u[1].u) < 8e-4
 
     @info "saveat and callbacks"
 
@@ -80,7 +80,7 @@ for alg in algs
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         saveat = [0.0f0, 9.1f0])
 
-    @test norm(bench_sol.u - sol[1].u) < 5e-4
+    @test norm(bench_sol.u - sol.u[1].u) < 5e-4
 
     @info "save_everystep and callbacks"
 
@@ -93,7 +93,7 @@ for alg in algs
         adaptive = false, dt = 0.1f0, callback = cb, merge_callbacks = true,
         save_everystep = false)
 
-    @test norm(bench_sol.u - sol[1].u) < 6e-4
+    @test norm(bench_sol.u - sol.u[1].u) < 6e-4
 
     @info "Adaptive version"
 
@@ -107,7 +107,7 @@ for alg in algs
         adaptive = true, save_everystep = false, dt = 0.1f0, callback = cb,
         merge_callbacks = true)
 
-    @test norm(bench_sol.u - sol[1].u) < 2e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-3
 
     @info "Callback: CallbackSets"
 
@@ -121,7 +121,7 @@ for alg in algs
         adaptive = true, dt = 0.1f0, save_everystep = false, callback = cb,
         merge_callbacks = true)
 
-    @test norm(bench_sol.u - sol[1].u) < 2e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-3
 
     @info "saveat and callbacks"
 
@@ -136,7 +136,7 @@ for alg in algs
         tstops = [24.0f0, 40.0f0], saveat = [0.0f0, 9.1f0], reltol = 1.0f-6,
         abstol = 1.0f-6)
 
-    @test norm(bench_sol.u - sol[1].u) < 6e-4
+    @test norm(bench_sol.u - sol.u[1].u) < 6e-4
 
     @info "Unadaptive and Adaptive comparison"
 
@@ -150,5 +150,5 @@ for alg in algs
         adaptive = true, dt = 0.1f0, callback = cb, merge_callbacks = true,
         saveat = [0.0f0, 9.1f0])
 
-    @test norm(asol[1].u - sol[1].u) < 7e-4
+    @test norm(asol.u[1].u - sol.u[1].u) < 7e-4
 end

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_discrete_callbacks.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_discrete_callbacks.jl
@@ -45,8 +45,8 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         tstops = [2.40f0])
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 2e-3
-    @test norm(bench_sol.u - sol[1].u) < 5e-3
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 2e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 5e-3
 
     #Test the truncation error due to floating point math, encountered when adjusting t for tstops
     local sol = solve(monteprob, alg, EnsembleGPUKernel(backend),
@@ -58,8 +58,8 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         adaptive = false, dt = 0.01f0, callback = cb, merge_callbacks = true,
         tstops = [4.0f0])
 
-    @test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 2e-6
-    @test norm(bench_sol.u - sol[1].u) < 3e-5
+    @test norm(bench_sol(4.0f0) - sol.u[1](4.0f0)) < 2e-6
+    @test norm(bench_sol.u - sol.u[1].u) < 3e-5
 
     @info "Callback: CallbackSets"
 
@@ -81,9 +81,9 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         tstops = [2.40f0, 4.0f0])
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 2e-3
-    @test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 3e-3
-    @test norm(bench_sol.u - sol[1].u) < 7e-3
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 2e-3
+    @test norm(bench_sol(4.0f0) - sol.u[1](4.0f0)) < 3e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 7e-3
 
     @info "saveat and callbacks"
 
@@ -96,9 +96,9 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         tstops = [2.40f0, 4.0f0], saveat = [0.0f0, 6.0f0])
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 1e-3
-    @test norm(bench_sol(6.0f0) - sol[1](6.0f0)) < 3e-3
-    @test norm(bench_sol.u - sol[1].u) < 3e-3
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 1e-3
+    @test norm(bench_sol(6.0f0) - sol.u[1](6.0f0)) < 3e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 3e-3
 
     @info "save_everystep and callbacks"
 
@@ -111,9 +111,9 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         tstops = [2.40f0, 4.0f0], save_everystep = false)
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 3e-5
-    @test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 5e-5
-    @test norm(bench_sol.u - sol[1].u) < 2e-4
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 3e-5
+    @test norm(bench_sol(4.0f0) - sol.u[1](4.0f0)) < 5e-5
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-4
 
     @info "Adaptive version"
 
@@ -129,8 +129,8 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         merge_callbacks = true,
         tstops = [4.0f0])
 
-    @test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 5e-5
-    @test norm(bench_sol.u - sol[1].u) < 2e-4
+    @test norm(bench_sol(4.0f0) - sol.u[1](4.0f0)) < 5e-5
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-4
 
     @info "Callback: CallbackSets"
 
@@ -144,9 +144,9 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         merge_callbacks = true,
         tstops = [2.40f0, 4.0f0])
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 6e-4
-    @test norm(bench_sol(4.0f0) - sol[1](4.0f0)) < 1e-3
-    @test norm(bench_sol.u - sol[1].u) < 3e-3
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 6e-4
+    @test norm(bench_sol(4.0f0) - sol.u[1](4.0f0)) < 1e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 3e-3
 
     @info "saveat and callbacks"
 
@@ -162,9 +162,9 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         tstops = [2.40f0, 4.0f0], saveat = [0.0f0, 6.0f0], reltol = 1.0f-7,
         abstol = 1.0f-7)
 
-    @test norm(bench_sol(2.40f0) - sol[1](2.40f0)) < 7e-3
-    @test norm(bench_sol(6.0f0) - sol[1](6.0f0)) < 2e-2
-    @test norm(bench_sol.u - sol[1].u) < 2e-2
+    @test norm(bench_sol(2.40f0) - sol.u[1](2.40f0)) < 7e-3
+    @test norm(bench_sol(6.0f0) - sol.u[1](6.0f0)) < 2e-2
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-2
 
     @info "Terminate callback"
 
@@ -179,6 +179,6 @@ for (alg, diffeq_alg) in zip(algs, diffeq_algs)
         adaptive = false, dt = 1.0f0, callback = cb, merge_callbacks = true,
         tstops = [2.40f0])
 
-    @test norm(bench_sol.t - sol[1].t) < 2e-3
-    @test norm(bench_sol.u - sol[1].u) < 5e-3
+    @test norm(bench_sol.t - sol.u[1].t) < 2e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 5e-3
 end

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_mass_matrix.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_mass_matrix.jl
@@ -35,5 +35,5 @@ sol = solve(monteprob, alg, EnsembleGPUKernel(backend),
     dt = 0.1f0,
     adaptive = true, abstol = 1.0f-5, reltol = 1.0f-5)
 
-@test norm(bench_sol.u[1] - sol[1].u[1]) < 8e-4
-@test norm(bench_sol.u[end] - sol[1].u[end]) < 8e-4
+@test norm(bench_sol.u[1] - sol.u[1].u[1]) < 8e-4
+@test norm(bench_sol.u[end] - sol.u[1].u[end]) < 8e-4

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
@@ -49,8 +49,8 @@ for alg in algs
         abstol = 1.0f-7,
         reltol = 1.0f-7)
 
-    @test norm(bench_sol.u[end] - sol[1].u[end]) < 5e-3
-    @test norm(bench_asol.u - asol[1].u) < 6e-3
+    @test norm(bench_sol.u[end] - sol.u[1].u[end]) < 5e-3
+    @test norm(bench_asol.u - asol.u[1].u) < 6e-3
 
     ### solve parameters
 
@@ -68,14 +68,14 @@ for alg in algs
         abstol = 1.0f-7,
         reltol = 1.0f-7, saveat = saveat)
 
-    @test norm(asol[1].u[end] - sol[1].u[end]) < 4e-2
+    @test norm(asol.u[1].u[end] - sol.u[1].u[end]) < 4e-2
 
-    @test norm(bench_sol.u - sol[1].u) < 2e-4
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-4
     #Use to fail for 2e-4
-    @test norm(bench_asol.u - asol[1].u) < 2e-3
+    @test norm(bench_asol.u - asol.u[1].u) < 2e-3
 
-    @test length(sol[1].u) == length(saveat)
-    @test length(asol[1].u) == length(saveat)
+    @test length(sol.u[1].u) == length(saveat)
+    @test length(asol.u[1].u) == length(saveat)
 
     saveat = collect(0.0f0:0.1f0:10.0f0)
 
@@ -92,13 +92,13 @@ for alg in algs
         reltol = 1.0f-7, saveat = saveat)
 
     #Fails also OrdinaryDiffEq.jl
-    # @test norm(asol[1].u[end] - sol[1].u[end]) < 6e-3
+    # @test norm(asol.u[1].u[end] - sol.u[1].u[end]) < 6e-3
 
-    @test norm(bench_sol.u - sol[1].u) < 2e-3
-    @test norm(bench_asol.u - asol[1].u) < 3e-2
+    @test norm(bench_sol.u - sol.u[1].u) < 2e-3
+    @test norm(bench_asol.u - asol.u[1].u) < 3e-2
 
-    @test length(sol[1].u) == length(saveat)
-    @test length(asol[1].u) == length(saveat)
+    @test length(sol.u[1].u) == length(saveat)
+    @test length(asol.u[1].u) == length(saveat)
 
     local sol = solve(monteprob, alg, EnsembleGPUKernel(backend), trajectories = 2,
         adaptive = false, dt = 0.01f0, save_everystep = false)
@@ -106,9 +106,9 @@ for alg in algs
     bench_sol = solve(prob, Rosenbrock23(), adaptive = false, dt = 0.01f0,
         save_everystep = false)
 
-    @test norm(bench_sol.u - sol[1].u) < 5e-3
+    @test norm(bench_sol.u - sol.u[1].u) < 5e-3
 
-    @test length(sol[1].u) == length(bench_sol.u)
+    @test length(sol.u[1].u) == length(bench_sol.u)
 
     ### Huge number of threads
     local sol = solve(monteprob, alg, EnsembleGPUKernel(backend, 0.0),


### PR DESCRIPTION
## Summary
- Fixes all Julia 1.11 deprecation warnings related to `AbstractVectorOfArray` indexing
- Changes `sol[i]` → `sol.u[i]` and `asol[i]` → `asol.u[i]` patterns across test files
- Addresses warnings: `Base.getindex(VA::AbstractVectorOfArray{T,N,A}, I::Int) is deprecated, use VA.u[I] instead`

## Changes
Fixed deprecation warnings in 12 test files:
- `test/ensemblegpuarray.jl` 
- `test/distributed_multi_gpu.jl`
- `test/gpu_kernel_de/gpu_ode_regression.jl`
- `test/gpu_kernel_de/gpu_sde_regression.jl` 
- `test/gpu_kernel_de/gpu_sde_convergence.jl`
- `test/gpu_kernel_de/finite_diff.jl`
- `test/gpu_kernel_de/gpu_ode_continuous_callbacks.jl`
- `test/gpu_kernel_de/gpu_ode_discrete_callbacks.jl`
- `test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl`
- `test/gpu_kernel_de/stiff_ode/gpu_ode_continuous_callbacks.jl`
- `test/gpu_kernel_de/stiff_ode/gpu_ode_discrete_callbacks.jl`
- `test/gpu_kernel_de/stiff_ode/gpu_ode_mass_matrix.jl`

Total: 107 instances of `sol.u[i]` and 19 instances of `asol.u[i]` patterns updated.

## Test plan
- [ ] Run existing CI tests to ensure no regressions
- [ ] Verify deprecation warnings are eliminated in Julia 1.11

🤖 Generated with [Claude Code](https://claude.ai/code)