### PR TITLE
[TEST] CUDA tests on V100 instead of T4

### DIFF
--- a/.github/workflows/GPU.yml
+++ b/.github/workflows/GPU.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   cuda-tests:
     name: "CUDA Tests (Julia ${{ matrix.version }})"
-    runs-on: [self-hosted, Linux, X64, gpu-t4]
+    runs-on: [self-hosted, Linux, X64, gpu-v100]
     timeout-minutes: 120
     strategy:
       fail-fast: false


### PR DESCRIPTION
Testing whether the `CUDA error: misaligned address` failure on arctic1 T4 runners also happens on V100 runners. DO NOT MERGE.