### PR TITLE
docs(ad): polish Lux example comments + retrigger Doc CI

### DIFF
--- a/docs/src/examples/ad.md
+++ b/docs/src/examples/ad.md
@@ -9,12 +9,12 @@ using OrdinaryDiffEq, SciMLSensitivity, Lux, Optimisers, Zygote, DiffEqGPU, CUDA
 
 CUDA.allowscalar(false)
 
-# A tiny Lux model whose parameters are what we train. It maps a constant
-# input to the two ODE parameters.
+# A tiny Lux model whose trainable parameters become the two ODE parameters
+# (a `Dense(1 => 2)` applied to a constant input).
 const dense = Dense(1 => 2)
 const x = Float32[1.0]
 rng = Random.default_rng()
-Random.seed!(rng, 0)
+Random.seed!(rng, 0)  # reproducibility
 ps, st = Lux.setup(rng, dense)
 
 u0 = Float32[3.0]


### PR DESCRIPTION
**Note: Please ignore this PR until reviewed by @ChrisRackauckas. Opening as a draft.**

## Summary

Tiny wording tweak to the Lux/AD example in `docs/src/examples/ad.md`:
- Tightened the comment describing the `Dense(1 => 2)` model.
- Added a `# reproducibility` hint next to the `Random.seed!` call.

## Why a follow-up PR

PR #442 (Flux → Lux + Optimisers + Zygote) was merged on 2026-04-30
with a failing Documentation CI run. The failure was a package
resolution error, not anything in the example code:

```
ERROR: Unsatisfiable requirements detected for package MLDataDevices [7e8f7934]:
  - restricted by compatibility requirements with RecursiveArrayTools [731186ca]
    to versions: uninstalled
  - restricted by compatibility requirements with Lux [b2108857]
    to versions: 1.5.0 - 1.17.8 — no versions left
```

`Lux 1.x` required `MLDataDevices ≤ 1.17.8`, but `RecursiveArrayTools v4`
(pinned by DiffEqGPU) needed a newer `MLDataDevices`. As of this week
that's been unblocked upstream — `MLDataDevices 1.17.10` resolves
cleanly with `RecursiveArrayTools 4.3.0` and `Lux 1.31.4`.

This PR exists primarily to retrigger the Doc CI on a current
registry snapshot now that the resolver conflict is gone.

## Test plan

- [x] `Pkg.instantiate` on `docs/Project.toml` resolves locally with
  the post-unblock registry — 81 deps precompile cleanly.
- [x] Lux training loop in the example runs end-to-end on CPU
  (`EnsembleSerial`):
  ```
  loss(ps) = 42.0898
  loss(ps) = 9.875094
  loss(ps) = 5.4691095
  ...
  ```
- [ ] Doc CI passes on this branch.
- [ ] Runic format-check passes.