### PR TITLE
test(reduction): use sol.u[end] for state-vector output

### DIFF
--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -14,7 +14,11 @@ end
 prob = ODEProblem(f!, [0.5], (0.0, 1.0))
 
 function output_func(sol, ctx)
-    return last(sol), false
+    # Use `sol.u[end]` rather than `last(sol)` so each per-trajectory output
+    # stays a state vector. In SciMLBase v3, `last(sol)` returns a scalar for
+    # single-component ODEs, which makes `sum(sim1.u)` a scalar and breaks the
+    # comparison against `sim2.u` (a 1-element vector from `u_init = [0.0]`).
+    return sol.u[end], false
 end
 
 function prob_func(prob, ctx)

--- a/test/reduction.jl
+++ b/test/reduction.jl
@@ -14,10 +14,6 @@ end
 prob = ODEProblem(f!, [0.5], (0.0, 1.0))
 
 function output_func(sol, ctx)
-    # Use `sol.u[end]` rather than `last(sol)` so each per-trajectory output
-    # stays a state vector. In SciMLBase v3, `last(sol)` returns a scalar for
-    # single-component ODEs, which makes `sum(sim1.u)` a scalar and breaks the
-    # comparison against `sim2.u` (a 1-element vector from `u_init = [0.0]`).
     return sol.u[end], false
 end
 


### PR DESCRIPTION
**Note: Please ignore this PR until reviewed by @ChrisRackauckas. Opening as a draft.**

## Summary

Fixes the `Reduction` testset error reported on the `arctic1-1`
self-hosted runner:

```
Reduction: Error During Test at .../test/reduction.jl:48
  Test threw exception
  Expression: sum(sim1.u) ≈ sim2.u
  MethodError: no method matching isapprox(::Float64, ::Vector{Float64})
```

Root cause: under SciMLBase v3, `last(sol)` for a 1-component ODE
now returns a `Float64` scalar rather than a 1-element
`Vector{Float64}`. With the existing `output_func` that flowed
through to:

- `sim1.u :: Vector{Float64}` (was `Vector{Vector{Float64}}`)
- `sum(sim1.u) :: Float64` (was `Vector{Float64}`)
- `sim2.u :: Vector{Float64}` (1-element, from `u_init = [0.0]`)

so `@test sum(sim1.u) ≈ sim2.u` ends up comparing a scalar to a
1-element vector and errors. The test file wasn't migrated for the
shape change when the rest of the suite moved to SciMLBase v3 /
RAT v4.

Switching `output_func` to return `sol.u[end]` (still a
`Vector{Float64}`) keeps each per-trajectory output as a state
vector, restoring the original shape semantics so the three
existing assertions hold without relaxing what they check.

## Test plan

- [x] `GROUP=JLArrays julia +1.10 --project=test` running the
  `Reduction` `@safetestset`:
  ```
  Test Summary: | Pass  Total   Time
  Reduction     |    3      3  24.1s
  ```
- [x] Runic format-check passes (`exit 0`).
- [ ] Self-hosted CUDA runner re-runs `Reduction`.