### PR TITLE
compat: restore CUDA v5 lower bound

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -45,7 +45,7 @@ oneAPIExt = ["oneAPI"]
 [compat]
 AMDGPU = "2"
 Adapt = "4"
-CUDA = "6"
+CUDA = "5, 6"
 ChainRulesCore = "1"
 DiffEqBase = "7"
 DocStringExtensions = "0.9"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -25,7 +25,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [compat]
 Adapt = "4"
 BenchmarkTools = "1"
-CUDA = "6"
+CUDA = "5, 6"
 DiffEqBase = "7"
 DiffEqGPU = "3"
 Documenter = "1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -34,7 +34,7 @@ pocl_jll = "627d6b7a-bbe6-5189-83e7-98cc0a5aeadd"
 [compat]
 Adapt = "4"
 BenchmarkTools = "1"
-CUDA = "6"
+CUDA = "5, 6"
 DiffEqDevTools = "3, 4.0"
 DiffEqGPU = "3"
 ForwardDiff = "1"


### PR DESCRIPTION
> [!NOTE]
> Draft PR — please ignore until reviewed by @ChrisRackauckas.

Closes #449.

## Why

PR #441 cleanup bumped `CUDA = "5, 6"` → `"6"` along with a batch of other major-version drops. The CUDA part was unnecessarily aggressive: CUDA 6 was released with no breaking changes from 5 (see [v6.0.0 release notes](https://github.com/JuliaGPU/CUDA.jl/releases/tag/v6.0.0)), and the lift broke downstream consumers like NeuralLyapunov whose stack still requires CUDA 5 transitively (via AdvancedHMC, see SciML/NeuralLyapunov.jl#175).

## What

`CUDA = "6"` → `CUDA = "5, 6"` in:
- `Project.toml`
- `test/Project.toml`
- `docs/Project.toml`

No code changes. The CUDAExt surface is tiny:

```julia
# ext/CUDAExt.jl
DiffEqGPU.maxthreads(::CUDABackend) = 256
DiffEqGPU.maybe_prefer_blocks(::CUDABackend) = CUDABackend(; prefer_blocks = true)
function DiffEqGPU.lufact!(::CUDABackend, W)
    CUDA.CUBLAS.getrf_strided_batched!(W, false)
    return nothing
end
```

`CUDA.CUDABackend` and `CUDA.CUBLAS.getrf_strided_batched!` are both stable across CUDA 5 and 6, so no shim is needed. Test code uses only `CUDA.CUDABackend()` (in `test/utils.jl`).

## Verification

Local resolution checks (Julia 1.10, no GPU on the test machine — CI will exercise the actual GPU paths):

```
# CUDA = "5, 6" in package + test envs
julia --project=test -e 'using Pkg; Pkg.add(PackageSpec(name="CUDA", version="5"))'
# → resolves to CUDA v5.11.2; DiffEqGPU.CUDAExt + LinearSolveCUDAExt + DiffEqBaseCUDAExt all precompile

julia --project=test -e 'using Pkg; Pkg.add(PackageSpec(name="CUDA", version="6"))'
# → resolves to CUDA v6.1.0; same extensions all precompile
```

Both endpoints of the new range resolve cleanly with the rest of the test stack (OrdinaryDiffEq 7, ModelingToolkit 11, SciMLBase 3, etc.).