### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
         exclude:
           - version: "pre"
             group: QA
-    uses: "SciML/.github/.github/workflows/tests.yml@master"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       julia-version: "${{ matrix.version }}"
       group: "${{ matrix.group }}"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,6 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
     # Disabled: MTK 10.18+ pins StaticArrays >= 1.9.14 but Downgrade pins
     # StaticArrays to its `Project.toml` floor. The required floor bump is a
     # cosmetic compat tightening unrelated to this package's actual runtime
@@ -23,17 +22,10 @@ jobs:
         downgrade_mode: ['alldeps']
         julia-version: ['1.10']
         group: ['CPU']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      group: "${{ matrix.group }}"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,4 +1,8 @@
 [default.extend-words]
+# Domain-specific identifiers (not typos)
+gam = "gam"     # gamma type/coefficient (gamType, γ)
+yhat = "yhat"   # ŷ, predictor value in implicit solvers
+
 # Julia-specific functions
 indexin = "indexin"
 findfirst = "findfirst"

--- a/docs/src/manual/backends.md
+++ b/docs/src/manual/backends.md
@@ -1,7 +1,7 @@
 # Compute Backends (GPU Choices)
 
 DiffEqGPU.jl supports a multitude of different GPU devices. These must be chosen during the
-construction of the `EnsembleGPUArray` and `EnsembleGPUKernel` construction and correpond
+construction of the `EnsembleGPUArray` and `EnsembleGPUKernel` construction and correspond
 to the compute backends of [KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl).
 The choices for backends are:
 


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the CI to use the centralized SciML reusable workflows everywhere, pinned to `@v1` with `secrets: "inherit"` on every caller.

## Converted (inline -> central caller)
- **Runic** (`FormatCheck.yml`): inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck** (`SpellCheck.yml`): inline `crate-ci/typos@v1.18.0` -> `spellcheck.yml@v1`
- **Downgrade** (`Downgrade.yml`): inline steps -> `downgrade.yml@v1`, preserving the `if: false` gate, the `1.10`/`CPU`/`alldeps` matrix, `skip: Pkg,TOML`, and `allow-reresolve: false` (was `ALLOW_RERESOLVE`)

## Updated
- **Tests** (`CI.yml`): already a `tests.yml` caller; pinned `@master` -> `@v1`. The `version × group` matrix (`1`/`lts`/`pre` × `CPU`/`JLArrays`/`OpenCL`/`QA`, excluding `pre`×`QA`) is unchanged. Already had `secrets: "inherit"`.

## Cleanup
- `dependabot.yml`: removed the `crate-ci/typos` ignore block (typos version is now centrally managed). `github-actions` (weekly, `/`) and `julia` (daily, all-julia-packages, dirs `/ /docs /test`) blocks preserved.

## Typos
- Fixed 1 genuine typo: `correpond` -> `correspond` in `docs/src/manual/backends.md`.
- Added domain false-positives `gam` (gamma type, `gamType`/`γ`) and `yhat` (ŷ predictor) to `.typos.toml`. `typos .` now exits 0.

## Runic
- Ran Runic 1.7.0 in place: no changes (repo was already Runic-clean from the inline check).

## Not changed (deliberately)
- **`GPU.yml`** (self-hosted CUDA tests + GPU documentation build): left as-is. The docs build runs on `[self-hosted, gpu-v100]` with `DATADEPS_ALWAYS_ACCEPT` because building the docs requires a CUDA GPU. The central `documentation.yml@v1` caller can only target the generic `self-hosted` label (not `gpu-v100`) and does not set `DATADEPS_ALWAYS_ACCEPT`, so converting it would break the docs build. No standalone `documentation.yml@v1` caller was added for the same reason (an ubuntu-latest docs build would fail on the CUDA-dependent content).
- `TagBot.yml`: unchanged.

## Heads-up
Check names change with this conversion (e.g. job names now come from the reusable workflows). **Branch-protection required-status-check names will need updating** to match the new caller job names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)