### PR TITLE
Re-enable Downgrade workflow (strict)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,11 +12,7 @@ on:
       - 'docs/**'
 jobs:
   test:
-    # Disabled: MTK 10.18+ pins StaticArrays >= 1.9.14 but Downgrade pins
-    # StaticArrays to its `Project.toml` floor. The required floor bump is a
-    # cosmetic compat tightening unrelated to this package's actual runtime
-    # requirements, so the workflow is parked until that's worth doing.
-    if: false
+    # Runs strict (no allow-reresolve); expected RED until the GPU stack / ForwardDiff-LogExpFunctions floors resolve.
     strategy:
       matrix:
         downgrade_mode: ['alldeps']


### PR DESCRIPTION
Removes the `if: false` that parked the Downgrade job so it runs again.

downgrade re-enabled strict; intentionally RED (natural failure, not disabled) pending GPU stack / ForwardDiff-LogExpFunctions; auto-greens when that resolves.

Kept strict (no `allow-reresolve`), did not lower floors, kept julia "1.10".

Please ignore this PR until reviewed by @ChrisRackauckas.