### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,24 +23,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        group:
-          - CPU
-          - JLArrays
-          - OpenCL
-          - QA
-        exclude:
-          - version: "pre"
-            group: QA
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,11 @@
+[CPU]
+versions = ["lts", "1", "pre"]
+
+[JLArrays]
+versions = ["lts", "1", "pre"]
+
+[OpenCL]
+versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
Converts the root test workflow (`.github/workflows/CI.yml`, `name: "Tests"`) to the canonical thin caller of `SciML/.github/.github/workflows/grouped-tests.yml@v1`, with the group × version matrix declared once in a root `test/test_groups.toml`.

## Change
- `.github/workflows/CI.yml`: the matrix `tests` job (group × version with the `pre`×`QA` exclude, previously calling `tests.yml@v1` per cell) is replaced by a single thin caller:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
  The filename, `name: "Tests"` (preserves branch-protection status checks), `on:` triggers, and `concurrency:` block are all kept verbatim.
- `test/test_groups.toml` (new, repo root): declares the matrix —
  - `CPU`, `JLArrays`, `OpenCL` on `["lts", "1", "pre"]`
  - `QA` on `["lts", "1"]`

No `with:` overrides are needed: `test/runtests.jl` already reads the standard `GROUP` env var (default `"CUDA"`), coverage stays enabled, coverage dirs are the default `src,ext`, there are no apt packages, and check-bounds is handled inside `runtests.jl` itself (it re-execs without `--check-bounds`).

This is Category A — `runtests.jl` already has `Core`/`QA`-style GROUP dispatch, so no `runtests.jl` change was made.

## Matrix verification
Ran `scripts/compute_affected_sublibraries.jl <root> --root-matrix` (from `SciML/.github@v1`) against the new TOML. Emitted set:

| group | versions |
|-------|----------|
| CPU | lts, 1, pre |
| JLArrays | lts, 1, pre |
| OpenCL | lts, 1, pre |
| QA | lts, 1 |

= 11 cells, all `runner: ubuntu-latest`, all `continue_on_error: false`. This reproduces the old hand-maintained matrix (3 versions × 4 groups − 1 excluded `pre`×`QA`) exactly: **11/11 exact**.

Linux-only: no `os` axis added (default `ubuntu-latest`). The separate `GPU.yml` (CUDA self-hosted + docs) and all other workflows (Downgrade, FormatCheck, SpellCheck, RunicSuggestions, TagBot, DependabotAutoMerge, DocPreviewCleanup) are left untouched.

## QA
None needed — QA group (JET) already exists in `runtests.jl`; this PR only does static matrix-verification (TOML + YAML parse, matrix reproduction). No source bugs uncovered.

Ignore until reviewed by @ChrisRackauckas.