### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline-julia.yml
+++ b/.buildkite/pipeline-julia.yml
@@ -1,0 +1,33 @@
+steps:
+  - label: ":julia: [Metal] Run tests on Julia v{{matrix.version}}"
+    matrix:
+      setup:
+        version:
+          - "1"
+          - "1.10"
+    env:
+      GROUP: Metal
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "{{matrix.version}}"
+    commands:
+      - |
+        julia --project=test -e '
+          import Pkg
+          Pkg.add(; name = "Metal")'
+        rm test/Manifest.toml
+        julia --project -e '
+          import Pkg
+          println("+++ :julia: Running tests")
+          Pkg.test(; coverage=false)'
+    agents:
+      queue: "juliaecosystem"
+      os: "macos"
+      arch: "aarch64"
+    timeout_in_minutes: 120
+    # Don't run Buildkite if the commit message includes the text [skip tests]
+    if: build.message !~ /\[skip tests\]/
+
+env:
+  JULIA_PKG_SERVER: "" # it often struggles with our large artifacts
+  # SECRET_CODECOV_TOKEN: "..."

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,3 @@
 steps:
   - label: ":pipeline: Launch Tests"
     command: buildkite-agent pipeline upload .buildkite/runtests.yml
-    agents:
-      queue: "juliaecosystem"
-      sandbox_capable: true

--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -21,8 +21,7 @@ steps:
           println("+++ :julia: Running tests")
           Pkg.test(; coverage=false)'
     agents:
-      queue: "juliagpu"
-      rocm: "*"
+      queue: "rocm"
     timeout_in_minutes: 120
     # Don't run Buildkite if the commit message includes the text [skip tests]
     if: build.message !~ /\[skip tests\]/
@@ -55,37 +54,7 @@ steps:
           println("+++ :julia: Running tests")
           Pkg.test(; coverage=false)'
     agents:
-      queue: "juliagpu"
-      intel: "*"
-    timeout_in_minutes: 120
-    # Don't run Buildkite if the commit message includes the text [skip tests]
-    if: build.message !~ /\[skip tests\]/
-
-  - label: ":julia: [Metal] Run tests on Julia v{{matrix.version}}"
-    matrix:
-      setup:
-        version:
-          - "1"
-          - "1.10"
-    env:
-      GROUP: Metal
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "{{matrix.version}}"
-    commands:
-      - |
-        julia --project=test -e '
-          import Pkg
-          Pkg.add(; name = "Metal")'
-        rm test/Manifest.toml
-        julia --project -e '
-          import Pkg
-          println("+++ :julia: Running tests")
-          Pkg.test(; coverage=false)'
-    agents:
-      queue: "juliaecosystem"
-      os: "macos"
-      arch: "aarch64"
+      queue: "oneapi"
     timeout_in_minutes: 120
     # Don't run Buildkite if the commit message includes the text [skip tests]
     if: build.message !~ /\[skip tests\]/


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag. Steps that targeted `queue: "juliagpu"` without a backend tag now use the cluster's default queue.

The launcher step in `pipeline.yml` only uploads the sub-pipeline, so its agent constraints (`queue: "juliaecosystem"`, `sandbox_capable`) have been removed; it now runs on the cluster's default queue.

Queues are cluster-scoped, so the macOS Metal step targeting the `juliaecosystem` queue cannot run from the JuliaGPU cluster anymore. It has been moved verbatim into `.buildkite/pipeline-julia.yml`, to be wired up to a separate ecosystem-cluster pipeline once that is back online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)