### PR TITLE
Canonicalize remaining plain @testset units to @safetestset

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,13 +35,13 @@ end
 @time @safetestset "GPU Kernelized DAE Mass Matrix" begin
     include("gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl")
 end
-@time @testset "GPU Kernelized Non Stiff ODE Regression" begin
+@time @safetestset "GPU Kernelized Non Stiff ODE Regression" begin
     include("gpu_kernel_de/gpu_ode_regression.jl")
 end
 @time @safetestset "GPU Kernelized Non Stiff ODE DiscreteCallback" begin
     include("gpu_kernel_de/gpu_ode_discrete_callbacks.jl")
 end
-@time @testset "GPU Kernelized Stiff ODE Regression" begin
+@time @safetestset "GPU Kernelized Stiff ODE Regression" begin
     include("gpu_kernel_de/stiff_ode/gpu_ode_regression.jl")
 end
 @time @safetestset "GPU Kernelized Stiff ODE DiscreteCallback" begin
@@ -86,7 +86,7 @@ if GROUP in SUPPORTS_DOUBLE_PRECISION
         include("reduction.jl")
     end
 
-    @time @testset "Lower level API" begin
+    @time @safetestset "Lower level API" begin
         include("lower_level_api.jl")
     end
 
@@ -105,17 +105,17 @@ end
 if GROUP == "CUDA"
     @testset "Callbacks" begin
         # Causes dynamic function invocation
-        @time @testset "GPU Kernelized Non Stiff ODE ContinuousCallback" begin
+        @time @safetestset "GPU Kernelized Non Stiff ODE ContinuousCallback" begin
             include("gpu_kernel_de/gpu_ode_continuous_callbacks.jl")
         end
-        @time @testset "GPU Kernelized Stiff ODE ContinuousCallback" begin
+        @time @safetestset "GPU Kernelized Stiff ODE ContinuousCallback" begin
             include("gpu_kernel_de/stiff_ode/gpu_ode_continuous_callbacks.jl")
         end
         # device Random not implemented yet
-        @time @testset "GPU Kernelized SDE Regression" begin
+        @time @safetestset "GPU Kernelized SDE Regression" begin
             include("gpu_kernel_de/gpu_sde_regression.jl")
         end
-        @time @testset "GPU Kernelized SDE Convergence" begin
+        @time @safetestset "GPU Kernelized SDE Convergence" begin
             include("gpu_kernel_de/gpu_sde_convergence.jl")
         end
     end


### PR DESCRIPTION
Converts the independent test units in `test/runtests.jl` that were still plain `@testset "X" begin include(...) end` into `@safetestset`, so each runs in its own module (test isolation + world-age safety), matching the units in this suite that are already `@safetestset`.

**Converted:**
- `GPU Kernelized Non Stiff ODE Regression`
- `GPU Kernelized Stiff ODE Regression`
- `Lower level API`
- The four nested units inside the `Callbacks` group: `Non Stiff ODE ContinuousCallback`, `Stiff ODE ContinuousCallback`, `SDE Regression`, `SDE Convergence`.

**Left unchanged:**
- `Distributed Multi-GPU` stays a plain `@testset` — distributed `addprocs`/`@everywhere` does not play nicely with modules (as the file comment notes).
- The outer `Callbacks` grouping `@testset` is kept as a wrapper; nested units inside it are now `@safetestset`.
- GROUP-dispatch ladder, QA/JET block, run logic, and all assertions are unchanged.

The included files are already self-contained (own `using` lines + shared `utils.jl` include), and SafeTestsets injects `using Test` into each module so the bare `@test` calls resolve. `SafeTestsets` is already a test dependency, so no `Project.toml` change was needed.

Verification: static — `Meta.parseall` of `runtests.jl` parses cleanly and Runic formatting passes. This is a GPU suite that requires GPU hardware, so it was not run locally; CI will verify.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)