### PR TITLE
Document exported API coverage

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -32,5 +32,6 @@ pages = [
         "manual/backends.md",
         "manual/optimal_trajectories.md",
         "manual/choosing_ensembler.md",
+        "manual/api.md",
     ],
 ]

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -32,6 +32,7 @@ pages = [
         "manual/backends.md",
         "manual/optimal_trajectories.md",
         "manual/choosing_ensembler.md",
+        "manual/developer_interfaces.md",
         "manual/api.md",
     ],
 ]

--- a/docs/src/manual/api.md
+++ b/docs/src/manual/api.md
@@ -1,0 +1,21 @@
+# API
+
+## Reexported Ensemble API
+
+DiffEqGPU reexports these ensemble and callback helper APIs from SciMLBase.jl and
+DiffEqBase.jl for compatibility with the SciML ensemble interface:
+
+  - `EnsembleProblem`
+  - `EnsembleSolution`
+  - `EnsembleSerial`
+  - `EnsembleThreads`
+  - `EnsembleDistributed`
+  - `BrownFullBasicInit`
+  - `CheckInit`
+  - `terminate!`
+
+## Lower-Level Algorithms
+
+```@docs
+LinSolveGPUSplitFactorize
+```

--- a/docs/src/manual/developer_interfaces.md
+++ b/docs/src/manual/developer_interfaces.md
@@ -1,0 +1,28 @@
+# Developer Interfaces
+
+The APIs on this page are developer-facing. They are documented and versioned so that
+DiffEqGPU, SciML, and solver-extension code can share the same contracts, but ordinary
+users should prefer the documented algorithm constructors and `solve` interface.
+
+## Ensemble Algorithms
+
+```@docs
+DiffEqGPU.EnsembleArrayAlgorithm
+DiffEqGPU.EnsembleKernelAlgorithm
+```
+
+## Kernel ODE and SDE Algorithms
+
+```@docs
+DiffEqGPU.GPUODEAlgorithm
+DiffEqGPU.GPUSDEAlgorithm
+DiffEqGPU.GPUODEImplicitAlgorithm
+```
+
+## Kernel Nonlinear Solvers
+
+```@docs
+DiffEqGPU.AbstractNLSolver
+DiffEqGPU.AbstractNLSolverCache
+DiffEqGPU.NLSolver
+```

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -44,12 +44,144 @@ import StaticArrays: StaticVecOrMat
 import StaticArrays: @_inline_meta, LU, StaticLUMatrix
 import SciMLBase: ImmutableODEProblem
 
+"""
+    EnsembleArrayAlgorithm <: SciMLBase.EnsembleAlgorithm
+
+Developer interface for ensemble algorithms that fuse a SciML ensemble into array-valued
+state and parameter problems before delegating each trajectory to an ordinary SciML
+differential equation solver.
+
+# Interface Rules
+
+Subtypes are used as the third positional argument to `solve(ensembleprob, alg,
+ensemblealg; trajectories, kwargs...)` for `SciMLBase.AbstractEnsembleProblem`s. A subtype
+must be accepted by DiffEqGPU's `SciMLBase.__solve` method and by the lower-level
+`vectorized_map_solve` path. It must define enough backend/device information for
+`vectorized_map_solve_up` to move the generated `u0` and `p` arrays to the execution
+backend, and it must preserve the SciML ensemble semantics for `prob_func`, `reduction`,
+`batch_size`, `trajectories`, and solver keyword arguments.
+
+# Implementations
+
+  - `EnsembleGPUArray`: runs the fused array problem on a KernelAbstractions backend.
+  - `EnsembleCPUArray`: keeps the same fused-array code path on CPU for debugging.
+
+# Examples
+
+```julia
+solve(ensemble_prob, Tsit5(), EnsembleGPUArray(backend); trajectories = 10_000)
+```
+"""
 abstract type EnsembleArrayAlgorithm <: SciMLBase.EnsembleAlgorithm end
+
+"""
+    EnsembleKernelAlgorithm <: SciMLBase.EnsembleAlgorithm
+
+Developer interface for ensemble algorithms that generate one GPU kernel for a complete
+fixed-size ODE or SDE solve.
+
+# Interface Rules
+
+Subtypes are used as the ensemble algorithm in `solve(ensembleprob, gpu_alg, ensemblealg;
+trajectories, kwargs...)`, where `gpu_alg` is a `GPUODEAlgorithm` or `GPUSDEAlgorithm`.
+The corresponding problem must be convertible to the kernel path with
+`make_prob_compatible`; in practice this means out-of-place dynamics over static state
+containers for `EnsembleGPUKernel`. Implementations must support the lower-level
+`vectorized_solve` and, for ODE algorithms, `vectorized_asolve` entry points used by
+`batch_solve_up_kernel`.
+
+# Implementations
+
+  - `EnsembleGPUKernel`: compiles a KernelAbstractions kernel for all trajectories in a
+    batch.
+
+# Examples
+
+```julia
+solve(ensemble_prob, GPUTsit5(), EnsembleGPUKernel(backend);
+    trajectories = 10_000, adaptive = false, dt = 0.1f0)
+```
+"""
 abstract type EnsembleKernelAlgorithm <: SciMLBase.EnsembleAlgorithm end
 
 ##Solvers for EnsembleGPUKernel
+"""
+    GPUODEAlgorithm <: SciMLBase.AbstractODEAlgorithm
+
+Developer interface for ODE algorithms supported by `EnsembleGPUKernel`.
+
+# Interface Rules
+
+Subtypes must be immutable algorithm selectors with all per-solve state allocated by the
+kernel integrator constructors. They are passed as the second positional argument to
+`solve(ensembleprob, alg, EnsembleGPUKernel(backend); kwargs...)` and to the lower-level
+`vectorized_solve`/`vectorized_asolve` functions. A subtype must have kernel integrator
+support in `batch_solve_up_kernel`, an order from `alg_order`, and any required tableau,
+interpolation, callback, nonlinear-solve, or mass-matrix support implemented in GPU-safe
+code.
+
+The ODE function must be GPU compilable. The kernel path is tested through the generic
+lower-level API by constructing compatible `ODEProblem`s and calling `vectorized_solve`
+and `vectorized_asolve` without reaching into solver internals.
+
+# Examples
+
+```julia
+DiffEqGPU.vectorized_solve(gpu_probs, prob, GPUTsit5(); dt = 0.1f0)
+```
+"""
 abstract type GPUODEAlgorithm <: SciMLBase.AbstractODEAlgorithm end
+
+"""
+    GPUSDEAlgorithm <: SciMLBase.AbstractSDEAlgorithm
+
+Developer interface for SDE algorithms supported by `EnsembleGPUKernel`.
+
+# Interface Rules
+
+Subtypes are passed as the SDE algorithm in `solve(ensembleprob, alg,
+EnsembleGPUKernel(backend); kwargs...)` and through the lower-level `vectorized_solve`
+entry point. Implementations must provide GPU-safe stepping code, static state support,
+and noise compatibility checks before launching kernels. Current kernel SDE algorithms are
+fixed-step methods and must reject unsupported noise structures rather than falling back to
+host-side behavior.
+
+# Examples
+
+```julia
+DiffEqGPU.vectorized_solve(gpu_probs, sde_prob, GPUEM();
+    dt = 0.01f0, save_everystep = false)
+```
+"""
 abstract type GPUSDEAlgorithm <: SciMLBase.AbstractSDEAlgorithm end
+
+"""
+    GPUODEImplicitAlgorithm{AD} <: GPUODEAlgorithm
+
+Developer interface for stiff ODE algorithms in the `EnsembleGPUKernel` path.
+
+# Type Parameters
+
+  - `AD`: Boolean-like type parameter indicating whether the algorithm may derive missing
+    Jacobian and time-gradient information with automatic differentiation. Constructors
+    accept `autodiff = Val{true}()` or `Val{false}()`.
+
+# Interface Rules
+
+Subtypes must implement the `GPUODEAlgorithm` rules and additionally provide GPU-safe
+linear/nonlinear solve support. They must either receive analytical Jacobian/time-gradient
+functions through the `ODEFunction` or use the `AD` parameter to select automatic or finite
+difference derivative construction. Their nonlinear solve path is expected to use
+`AbstractNLSolver` state built by `build_nlsolver` and to solve static linear systems with
+DiffEqGPU's GPU-compatible linear algebra utilities.
+
+# Examples
+
+```julia
+solve(ensemble_prob, GPURodas4(autodiff = Val{false}()),
+    EnsembleGPUKernel(backend); trajectories = 10_000)
+```
+"""
 abstract type GPUODEImplicitAlgorithm{AD} <: GPUODEAlgorithm end
 
 _unwrap_val(B) = B

--- a/src/ensemblegpuarray/kernels.jl
+++ b/src/ensemblegpuarray/kernels.jl
@@ -368,7 +368,19 @@ end
 
 ### GPU Factorization
 """
-A parameter-parallel `SciMLLinearSolveAlgorithm`.
+    LinSolveGPUSplitFactorize()
+    LinSolveGPUSplitFactorize(len, nfacts)
+
+A parameter-parallel `SciMLLinearSolveAlgorithm` for applying pre-factorized
+per-trajectory linear systems on a KernelAbstractions backend.
+
+# Arguments
+
+  - `len`: the size of each factored linear system.
+  - `nfacts`: the number of factorizations stored in the batched factorization array.
+
+Most users do not need to construct this directly; `EnsembleGPUArray` installs it for
+compatible stiff ensemble solves.
 """
 struct LinSolveGPUSplitFactorize <: LinearSolve.SciMLLinearSolveAlgorithm
     len::Int

--- a/src/ensemblegpukernel/gpukernel_algorithms.jl
+++ b/src/ensemblegpukernel/gpukernel_algorithms.jl
@@ -1,65 +1,141 @@
 """
-GPUTsit5()
+    GPUTsit5()
 
-A specialized implementation of the 5th order `Tsit5` method specifically for kernel
-generation with EnsembleGPUKernel. For a similar CPU implementation, see
-SimpleATsit5 from SimpleDiffEq.jl.
+Fifth-order Tsitouras Runge-Kutta method specialized for `EnsembleGPUKernel` ODE
+solves.
+
+Use `GPUTsit5` as the ODE algorithm when solving an `EnsembleProblem` with
+`EnsembleGPUKernel`:
+
+```julia
+solve(
+    ensemble_prob, GPUTsit5(), EnsembleGPUKernel(backend);
+    trajectories = 10_000, adaptive = false, dt = 0.1f0
+)
+```
+
+`GPUTsit5` supports the `EnsembleGPUKernel` restrictions, including out-of-place ODE
+functions over GPU-compatible static state containers. For a similar CPU implementation,
+see `SimpleATsit5` from SimpleDiffEq.jl.
 """
 struct GPUTsit5 <: GPUODEAlgorithm end
 
 """
-GPUVern7()
+    GPUVern7()
 
-A specialized implementation of the 7th order `Vern7` method specifically for kernel
-generation with EnsembleGPUKernel.
+Seventh-order Verner Runge-Kutta method specialized for `EnsembleGPUKernel` ODE
+solves.
+
+Use `GPUVern7` for non-stiff ODE ensemble solves that satisfy the `EnsembleGPUKernel`
+kernel-generation restrictions:
+
+```julia
+solve(
+    ensemble_prob, GPUVern7(), EnsembleGPUKernel(backend);
+    trajectories = 10_000, adaptive = false, dt = 0.1f0
+)
+```
 """
 struct GPUVern7 <: GPUODEAlgorithm end
 
 """
-GPUVern9()
+    GPUVern9()
 
-A specialized implementation of the 9th order `Vern9` method specifically for kernel
-generation with EnsembleGPUKernel.
+Ninth-order Verner Runge-Kutta method specialized for `EnsembleGPUKernel` ODE solves.
+
+Use `GPUVern9` for high-accuracy non-stiff ODE ensemble solves that satisfy the
+`EnsembleGPUKernel` kernel-generation restrictions:
+
+```julia
+solve(
+    ensemble_prob, GPUVern9(), EnsembleGPUKernel(backend);
+    trajectories = 10_000, adaptive = false, dt = 0.1f0
+)
+```
 """
 struct GPUVern9 <: GPUODEAlgorithm end
 
 """
-GPURosenbrock23()
+    GPURosenbrock23(; autodiff = Val{true}())
 
-A specialized implementation of the W-method `Rosenbrock23` method specifically for kernel
-generation with EnsembleGPUKernel.
+Second/third-order Rosenbrock-W method specialized for stiff `EnsembleGPUKernel` ODE
+solves.
+
+# Keyword Arguments
+
+  - `autodiff`: whether automatic differentiation is used for derivative generation.
+    Pass `Val{false}()` when providing the required derivatives manually.
+
+```julia
+solve(
+    ensemble_prob, GPURosenbrock23(), EnsembleGPUKernel(backend);
+    trajectories = 10_000
+)
+```
 """
 struct GPURosenbrock23{AD} <: GPUODEImplicitAlgorithm{AD} end
 
 """
-GPURodas4()
+    GPURodas4(; autodiff = Val{true}())
 
-A specialized implementation of the `Rodas4` method specifically for kernel
-generation with EnsembleGPUKernel.
+Fourth-order Rosenbrock method specialized for stiff `EnsembleGPUKernel` ODE solves.
+
+# Keyword Arguments
+
+  - `autodiff`: whether automatic differentiation is used for derivative generation.
+    Pass `Val{false}()` when providing the required derivatives manually.
+
+```julia
+solve(ensemble_prob, GPURodas4(), EnsembleGPUKernel(backend); trajectories = 10_000)
+```
 """
 struct GPURodas4{AD} <: GPUODEImplicitAlgorithm{AD} end
 
 """
-GPURodas5P()
+    GPURodas5P(; autodiff = Val{true}())
 
-A specialized implementation of the `Rodas5P` method specifically for kernel
-generation with EnsembleGPUKernel.
+Fifth-order Rosenbrock method specialized for stiff `EnsembleGPUKernel` ODE solves.
+
+# Keyword Arguments
+
+  - `autodiff`: whether automatic differentiation is used for derivative generation.
+    Pass `Val{false}()` when providing the required derivatives manually.
+
+```julia
+solve(ensemble_prob, GPURodas5P(), EnsembleGPUKernel(backend); trajectories = 10_000)
+```
 """
 struct GPURodas5P{AD} <: GPUODEImplicitAlgorithm{AD} end
 
 """
-GPUKvaerno3()
+    GPUKvaerno3(; autodiff = Val{true}())
 
-A specialized implementation of the `Kvaerno3` method specifically for kernel
-generation with EnsembleGPUKernel.
+Third-order ESDIRK method specialized for stiff `EnsembleGPUKernel` ODE solves.
+
+# Keyword Arguments
+
+  - `autodiff`: whether automatic differentiation is used for derivative generation.
+    Pass `Val{false}()` when providing the required derivatives manually.
+
+```julia
+solve(ensemble_prob, GPUKvaerno3(), EnsembleGPUKernel(backend); trajectories = 10_000)
+```
 """
 struct GPUKvaerno3{AD} <: GPUODEImplicitAlgorithm{AD} end
 
 """
-GPUKvaerno5()
+    GPUKvaerno5(; autodiff = Val{true}())
 
-A specialized implementation of the `Kvaerno5` method specifically for kernel
-generation with EnsembleGPUKernel.
+Fifth-order ESDIRK method specialized for stiff `EnsembleGPUKernel` ODE solves.
+
+# Keyword Arguments
+
+  - `autodiff`: whether automatic differentiation is used for derivative generation.
+    Pass `Val{false}()` when providing the required derivatives manually.
+
+```julia
+solve(ensemble_prob, GPUKvaerno5(), EnsembleGPUKernel(backend); trajectories = 10_000)
+```
 """
 struct GPUKvaerno5{AD} <: GPUODEImplicitAlgorithm{AD} end
 
@@ -72,17 +148,31 @@ for Alg in [:GPURosenbrock23, :GPURodas4, :GPURodas5P, :GPUKvaerno3, :GPUKvaerno
 end
 
 """
-GPUEM()
+    GPUEM()
 
-A specialized implementation of the Euler-Maruyama `GPUEM` method with weak order 1.0. Made specifically for kernel
-generation with EnsembleGPUKernel.
+Euler-Maruyama method with weak order 1.0 specialized for `EnsembleGPUKernel` SDE
+solves.
+
+```julia
+solve(
+    ensemble_prob, GPUEM(), EnsembleGPUKernel(backend);
+    trajectories = 10_000, adaptive = false, dt = 0.1f0
+)
+```
 """
 struct GPUEM <: GPUSDEAlgorithm end
 
 """
-GPUSIEA()
+    GPUSIEA()
 
-A specialized implementation of the weak order 2.0 for Ito SDEs `GPUSIEA` method specifically for kernel
-generation with EnsembleGPUKernel.
+Weak order 2.0 SIEA method for Ito SDEs specialized for `EnsembleGPUKernel` SDE
+solves.
+
+```julia
+solve(
+    ensemble_prob, GPUSIEA(), EnsembleGPUKernel(backend);
+    trajectories = 10_000, adaptive = false, dt = 0.1f0
+)
+```
 """
 struct GPUSIEA <: GPUSDEAlgorithm end

--- a/src/ensemblegpukernel/nlsolve/type.jl
+++ b/src/ensemblegpukernel/nlsolve/type.jl
@@ -1,6 +1,81 @@
+"""
+    AbstractNLSolver
+
+Developer interface for nonlinear solver state used by stiff `EnsembleGPUKernel`
+integrators.
+
+# Interface Rules
+
+Subtypes are mutable-by-replacement state containers used inside GPU kernel integrators.
+They must store the current stage correction, temporary stage state, derivative scaling,
+Jacobian/W-operator constructors, time-step metadata, parameters, and iteration counters
+needed by `nlsolve`. A subtype must be usable from GPU-compiled code: all fields and all
+functions called from `nlsolve` must be concrete and GPU compatible, and the state update
+must return the updated solver value rather than relying on host mutation.
+
+Implicit kernel algorithms build this state with `build_nlsolver` and then call
+`nlsolve(nlsolver, integrator)` from the generic step implementation. The required public
+behavior is tested through generic stiff `EnsembleGPUKernel` solves and the lower-level
+`vectorized_solve`/`vectorized_asolve` paths rather than by inspecting solver fields.
+
+# Fields
+
+Concrete subtypes are expected to provide the fields read by `nlsolve`, including `z`,
+`tmp`, `γ`, `c`, `J`, `W`, `dt`, `t`, `p`, `iter`, and `maxiters`.
+"""
 abstract type AbstractNLSolver end
+
+"""
+    AbstractNLSolverCache
+
+Developer interface for nonlinear solver cache objects used by future
+`EnsembleGPUKernel` nonlinear solver implementations.
+
+# Interface Rules
+
+Subtypes are reserved for GPU-compatible nonlinear solver caches. Cache fields must be
+static or otherwise acceptable to KernelAbstractions kernels, and methods using the cache
+must be callable from device code. A cache must not depend on host-only allocation,
+reflection, dynamic dispatch, BLAS/LAPACK calls, or non-bitstype closures in the kernel
+step path.
+
+This is developer-facing API for DiffEqGPU solver implementations. User code should select
+documented algorithms such as `GPURodas4` or `GPUKvaerno5` instead of constructing
+nonlinear solver caches directly.
+"""
 abstract type AbstractNLSolverCache end
 
+"""
+    NLSolver{uType, gamType, tmpType, tType, JType, WType, pType} <: AbstractNLSolver
+
+Concrete Newton-style nonlinear solver state used by stiff `EnsembleGPUKernel`
+integrators.
+
+# Fields
+
+  - `z`: current nonlinear correction.
+  - `tmp`: stage state used by DIRK and multistep methods.
+  - `tmp2`: additional temporary state for methods that need a second work vector.
+  - `ztmp`: temporary correction storage.
+  - `γ`: method coefficient multiplying the nonlinear correction.
+  - `c`: stage abscissa.
+  - `α`: method-specific stage coefficient.
+  - `κ`: nonlinear convergence damping parameter.
+  - `J`: callable Jacobian builder `J(u, p, t)`.
+  - `W`: callable W-operator builder `W(u, p, t)`.
+  - `dt`: current step size.
+  - `t`: current step start time.
+  - `p`: parameters for the current trajectory.
+  - `iter`: current nonlinear iteration count.
+  - `maxiters`: maximum nonlinear iterations.
+
+# Interface Rules
+
+`NLSolver` is constructed by `build_nlsolver`, consumed by `nlsolve`, and updated by
+returning a new value with modified fields. It is not intended as a direct user
+constructor; users select a stiff GPU algorithm and provide GPU-compatible derivative
+functions or enable algorithm-controlled differentiation.
+"""
 struct NLSolver{uType, gamType, tmpType, tType, JType, WType, pType} <: AbstractNLSolver
     z::uType
     tmp::uType # DIRK and multistep methods only use tmp

--- a/test/qa/public_api_docs.jl
+++ b/test/qa/public_api_docs.jl
@@ -1,0 +1,87 @@
+using DiffEqGPU, Test
+
+function docs_entries(root)
+    entries = Set{String}()
+    declarations = Set{String}()
+    in_docs_block = false
+
+    md_files = String[]
+    for (dir, _, files) in walkdir(root)
+        append!(md_files, joinpath.(dir, filter(endswith(".md"), files)))
+    end
+
+    for file in md_files
+        for line in eachline(file)
+            stripped = strip(line)
+            if stripped == "```@docs"
+                in_docs_block = true
+                continue
+            elseif startswith(stripped, "```")
+                in_docs_block = false
+                continue
+            end
+
+            for m in eachmatch(r"`([A-Za-z_][A-Za-z_0-9!]*)(?:\([^`]*)?`", line)
+                push!(declarations, m.captures[1])
+            end
+
+            if in_docs_block && !isempty(stripped)
+                push!(entries, stripped)
+                push!(entries, last(split(stripped, ".")))
+                push!(declarations, stripped)
+                push!(declarations, last(split(stripped, ".")))
+            end
+        end
+    end
+
+    return entries, declarations
+end
+
+@testset "Public API docs coverage" begin
+    exported_names = setdiff(names(DiffEqGPU; all = false), (:DiffEqGPU,))
+    missing_docstrings = Symbol[]
+
+    for name in exported_names
+        Docs.hasdoc(DiffEqGPU, name) || push!(missing_docstrings, name)
+    end
+
+    @test isempty(missing_docstrings)
+end
+
+@testset "Rendered API docs coverage" begin
+    root = joinpath(pkgdir(DiffEqGPU), "docs", "src")
+    entries, declarations = docs_entries(root)
+    exported_names = setdiff(names(DiffEqGPU; all = false), (:DiffEqGPU,))
+
+    missing_export_declarations = Symbol[
+        name for name in exported_names if String(name) ∉ declarations
+    ]
+    missing_owned_exports = Symbol[]
+
+    for name in exported_names
+        binding = getproperty(DiffEqGPU, name)
+        parentmodule(binding) === DiffEqGPU || continue
+        String(name) ∈ entries || push!(missing_owned_exports, name)
+    end
+
+    developer_interfaces = (
+        :EnsembleArrayAlgorithm,
+        :EnsembleKernelAlgorithm,
+        :GPUODEAlgorithm,
+        :GPUSDEAlgorithm,
+        :GPUODEImplicitAlgorithm,
+        :AbstractNLSolver,
+        :AbstractNLSolverCache,
+        :NLSolver,
+        :vectorized_solve,
+        :vectorized_asolve,
+        :vectorized_map_solve,
+    )
+    missing_developer_interfaces = Symbol[
+        name for name in developer_interfaces if String(name) ∉ entries
+    ]
+
+    @test isempty(missing_export_declarations)
+    @test isempty(missing_owned_exports)
+    @test isempty(missing_developer_interfaces)
+end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -49,3 +49,5 @@ run_qa(
         ),
     ),
 )
+
+include("public_api_docs.jl")


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Documents DiffEqGPU public/exported APIs in rendered docs, including reexported ensemble/callback APIs and package-owned algorithm constructors.
- Adds a developer-facing interfaces page for extension APIs used by solver/backend implementations.
- Moves interface docstrings to definition points and expands them with usage/interface rules and examples.
- Adds QA coverage checks that exported names have docstrings, exported names are declared in rendered docs, package-owned exports are in `@docs`, and developer extension points stay documented.

## Audit

- Explicit `export` entries audited: 22
- `public` markers found in this repo: 0
- SciMLPublic/`@public` markers found in this repo: 0
- Missing source/original docstrings after this change: 0
- Missing rendered docs/API-page coverage after this change: 0

## Validation

- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --startup-file=no -e 'using Runic; for file in ARGS; Runic.format_file(file; inplace = true); end' docs/pages.jl src/DiffEqGPU.jl src/ensemblegpukernel/nlsolve/type.jl test/qa/qa.jl test/qa/public_api_docs.jl` passed.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project=. --startup-file=no -e 'using DiffEqGPU; include("test/qa/public_api_docs.jl")'` passed: public API docs coverage 1/1, rendered API docs coverage 3/3.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project=. --startup-file=no -e 'using Pkg; withenv("GROUP" => "QA") do; Pkg.test(); end'` passed: Quality Assurance 22/22, JET static analysis 75/75.
- `git diff --check` passed.

## Docs Build

I also ran the docs build against the local checkout with:

```sh
timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project=docs --startup-file=no -e 'using Pkg; Pkg.develop(Pkg.PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'
```

Documenter reached the final checks without `:docs_block` errors and failed only with `[:example_block]`. The observed example failures are pre-existing/external to this API-doc coverage patch:

- `UndefVarError: islinear not defined in FunctionProperties` while precompiling/loading SciMLSensitivity extensions.
- `CUDA driver not functional` in CUDA examples on this machine.
- `UndefVarError: Rodas5 not defined` in an existing tutorial example.
- A ModelingToolkit GPU example error: `CuArray only supports element types that are allocated inline`.

## Process Notes

- Started from current `origin/master` and worked on a feature branch, not `master`.
- Did not skip, silence, or weaken tests/docs.
- PR branch is pushed from the `ChrisRackauckas-Claude` fork.
