### PR TITLE
Bump version to 3.15.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqGPU"
 uuid = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 authors = ["Chris Rackauckas", "SciML"]
-version = "3.15.2"
+version = "3.15.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Automated patch version bump (3.15.2 -> 3.15.3) to release unreleased commits on `master` via JuliaRegistrator.