### PR TITLE
Bump DiffEqGPU to v3.15.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqGPU"
 uuid = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 authors = ["Chris Rackauckas", "SciML"]
-version = "3.15.3"
+version = "3.15.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Bumps `DiffEqGPU` **v3.15.3 → v3.15.4** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Migrate DiffEqGPU QA to SciMLTesting 2.4 (#478) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)