### PR TITLE
Fix the docs examples blocking the Documenter deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ u0 = @SVector [1.0f0; 0.0f0; 0.0f0]
 tspan = (0.0f0, 10.0f0)
 p = @SVector [10.0f0, 28.0f0, 8 / 3.0f0]
 prob = ODEProblem{false}(lorenz, u0, tspan, p)
-prob_func = (prob, i, repeat) -> remake(prob, p = (@SVector rand(Float32, 3)) .* p)
+prob_func = (prob, ctx) -> remake(prob, p = (@SVector rand(Float32, 3)) .* p)
 monteprob = EnsembleProblem(prob, prob_func = prob_func, safetycopy = false)
 
 @time sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),

--- a/docs/src/examples/ad.md
+++ b/docs/src/examples/ad.md
@@ -4,7 +4,16 @@
 and thus can be thrown into deep learning training loops. The following is an example
 of this use:
 
-```@example ad
+!!! warning
+    
+    Reverse mode over `EnsembleGPUArray` is currently broken and this example does not
+    run. `Zygote.gradient` fails inside the pullback of `batch_solve` with
+    `DimensionMismatch: array with ndims(x) == 1 > 0 cannot have dx::Number`, because the
+    cotangent reaching `solus[i]` is a scalar where a `Vector{Vector}` is required. The
+    forward pass and the forward-mode example below are unaffected. This block is left
+    unevaluated until that is fixed.
+
+```julia
 using OrdinaryDiffEq, SciMLSensitivity, Lux, Optimisers, Zygote, DiffEqGPU, CUDA, Random
 
 CUDA.allowscalar(false)
@@ -59,7 +68,7 @@ Forward-mode automatic differentiation works as well, as demonstrated by its cap
 to recompile for Dual number arithmetic:
 
 ```@example ad
-using OrdinaryDiffEq, DiffEqGPU, ForwardDiff, Test
+using OrdinaryDiffEq, DiffEqGPU, ForwardDiff, Test, CUDA
 
 function lorenz(du, u, p, t)
     du[1] = p[1] * (u[2] - u[1])

--- a/docs/src/tutorials/gpu_ensemble_basic.md
+++ b/docs/src/tutorials/gpu_ensemble_basic.md
@@ -104,6 +104,6 @@ func = ODEFunction(lorenz, jac = lorenz_jac, tgrad = lorenz_tgrad)
 prob_jac = ODEProblem(func, u0, tspan, p)
 monteprob_jac = EnsembleProblem(prob_jac, prob_func = prob_func)
 
-solve(monteprob_jac, Rodas5(), EnsembleGPUArray(CUDA.CUDABackend()), trajectories = 10_000,
+solve(monteprob_jac, Rodas5P(), EnsembleGPUArray(CUDA.CUDABackend()), trajectories = 10_000,
     saveat = 1.0f0)
 ```

--- a/docs/src/tutorials/modelingtoolkit.md
+++ b/docs/src/tutorials/modelingtoolkit.md
@@ -10,8 +10,7 @@ tutorial showcases how to effectively use MTK with DiffEqGPU.jl.
 !!! warn
     
     This tutorial currently only works for ODEs defined by ModelingToolkit. More work
-    will be required to support DAEs in full. This is work that is ongoing and expected
-    to be completed by the summer of 2025.
+    will be required to support DAEs in full. This is work that is ongoing.
 
 The core aspect to doing this right is two things. First of all, MTK respects the types
 chosen by the user, and thus in order for GPU kernel generation to work the user needs
@@ -29,24 +28,38 @@ eqs = [D(D(x)) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,
     D(z) ~ x * y - β * z]
 
-@mtkbuild sys = ODESystem(eqs, t)
-u0 = @SVector [D(x) => 2.0f0,
+@named lorenz = System(eqs, t)
+sys = mtkcompile(lorenz; split = false)
+
+op = @SVector [D(x) => 2.0f0,
     x => 1.0f0,
     y => 0.0f0,
-    z => 0.0f0]
-
-p = @SVector [σ => 28.0f0,
+    z => 0.0f0,
+    σ => 28.0f0,
     ρ => 10.0f0,
     β => 8.0f0 / 3.0f0]
 
 tspan = (0.0f0, 100.0f0)
-prob = ODEProblem{false}(sys, u0, tspan, p)
+prob = ODEProblem{false}(sys, op, tspan)
 sol = solve(prob, Tsit5())
 ```
 
-with the core aspect to notice are the `SA`
-[StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl) annotations on the parts
-for the problem construction, along with the use of `Float32`.
+There are two things to notice here. The first is the `split = false` argument to
+`mtkcompile`. By default MTK builds an `MTKParameters` object, which stores the parameters
+in separate buffers grouped by how they are used. That object holds `Vector`s and is
+therefore not `isbits`, so it cannot be placed into a GPU kernel. `split = false` instead
+puts every parameter into a single flat buffer.
+
+The second is that the operating point `op` is given as a single
+[StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl) vector of pairs, using
+`Float32` values. MTK builds `u0` and `p` in the same container type it was handed, so a
+static vector in gives static vectors out:
+
+```@example mtk
+typeof(prob.u0), typeof(prob.p)
+```
+
+Both are `isbits` and thus usable from a GPU kernel.
 
 Now one of the difficulties for building an ensemble problem is that we must make a kernel
 for how to construct the problems, but the use of symbolics is inherently dynamic. As such,
@@ -72,7 +85,18 @@ u0, p = sym_setter(prob, SVector{3}(rand(Float32, 3)))
 Notice it takes in the vector of values for `[σ, ρ, β]` and spits out the new `u0, p`. So
 we can build and solve an MTK generated ODE on the GPU using the following:
 
-```@example mtk
+!!! warning
+    
+    The two blocks below do not currently run. `EnsembleGPUKernel` moves the vector of
+    problems to the device, which requires the whole `ImmutableODEProblem` to be
+    `isbitstype`. An MTK-generated `ODEFunction` never is: `f.sys`, `f.observed`,
+    `f.initialization_data` and `f.nlstep_data` all hold non-inline data, so the
+    conversion fails with `CuArray only supports element types that are allocated
+    inline`. Making `u0` and `p` static, as above, is necessary but not sufficient.
+    See [DiffEqGPU.jl#375](https://github.com/SciML/DiffEqGPU.jl/issues/375). These
+    blocks are left unevaluated until the device conversion strips those fields.
+
+```julia
 using DiffEqGPU, CUDA
 function prob_func2(prob, ctx)
     u0, p = sym_setter(prob, SVector{3}(rand(Float32, 3)))
@@ -86,6 +110,6 @@ sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),
 
 We can then using symbolic indexing on the result to inspect it:
 
-```@example mtk
+```julia
 [sol.u[i][y] for i in 1:length(sol.u)]
 ```


### PR DESCRIPTION
## Why

Reported on Discourse: [no method matching error when running DiffEqGPU example from docs](https://discourse.julialang.org/t/no-method-matching-error-when-running-diffeqgpu-example-from-docs/138471). A user copied the ensemble example from docs.sciml.ai and got:

```
ERROR: MethodError: no method matching (::var"#497#498")(::ODEProblem{…}, ::EnsembleContext{…})
Closest candidates are:
  (::var"#497#498")(::Any, ::Any, ::Any)
```

Their `prob_func` was the three-argument form. SciMLBase v3 moved to a single two-argument form — `basic_ensemble_solve.jl` now calls `prob.prob_func(_prob, ctx)` unconditionally, with the comment *"single 2-arg form, no arity detection needed"* — and DiffEqGPU was migrated to match in 90813db.

The docs sources in this repo were already correct. **The deployed site was not.** `gh-pages` had not moved since 2023:

```
$ gh api repos/SciML/DiffEqGPU.jl/commits/gh-pages
2023-11-25T20:58:24Z  b0ddbfb6  build based on 3e8c7e0
```

Both `/stable/` and `/dev/` still served the three-argument form. `DiffEqDocs` is current, so this was isolated to DiffEqGPU.

The cause: the `gpu-docs` job in `GPU.yml` (added in 66964b8, March 2026) has failed on **every** run since it was added. `makedocs` aborts with `[:example_block]` before `deploydocs` is reached, so nothing ever deploys. Four `@example` blocks were failing.

## What this changes

### `gpu_ensemble_basic.md` — `UndefVarError: Rodas5`

OrdinaryDiffEq v7 dropped the blanket `@reexport`. It now re-exports only `Rosenbrock23` and `Rodas5P` from OrdinaryDiffEqRosenbrock:

```julia
using OrdinaryDiffEqRosenbrock: Rosenbrock23, Rodas5P
export Rosenbrock23, Rodas5P
```

Switched to `Rodas5P()`. It is the only stiff solver in the docs affected; `Rosenbrock23` and `SOSRI` are still in scope.

### `modelingtoolkit.md` — updated for MTK v11

`@mtkbuild sys = ODESystem(...)` with `ODEProblem{false}(sys, u0, tspan, p)` is deprecated on MTK v11 and, more importantly, no longer produces GPU-compatible containers. Verified locally against the versions CI resolves (ModelingToolkit v11.36.0, OrdinaryDiffEq v7.1.3):

| | before | after |
|---|---|---|
| `prob.u0` | `Vector{Float32}` | `SVector{4, Float32}` |
| `prob.p` | `MTKParameters{Vector{Float32},…}`, `isbits = false` | `SVector{10, Float32}`, `isbits = true` |

Two changes were needed. `mtkcompile(lorenz; split = false)` keeps parameters in one flat buffer instead of an `MTKParameters` struct holding `Vector`s — that struct is the `CuArray only supports element types that are allocated inline` error. And the operating point is now passed as a single `@SVector` of pairs to the non-deprecated `ODEProblem{false}(sys, op, tspan)`, because MTK builds `u0`/`p` in the container type it is handed (`u0Type = pType = typeof(op)`).

The fourth build error, `ArgumentError: invalid index: y(t)`, was only a cascade of this one. `sol` was still the single non-ensemble solution bound in the earlier block, so `sol.u[i]` was a plain state vector rather than a solution.

### `ad.md` and the MTK GPU blocks — marked unevaluated

Two failures are genuine package bugs, not documentation errors, and are left as non-executing `julia` blocks with an explanation so the build can go green and deploy:

1. **Reverse mode over `EnsembleGPUArray`.** `Zygote.gradient` fails in the pullback of `batch_solve`: the cotangent reaching `solus[i]` is a `Float32` where a `Vector{Vector{Float32}}` is required, so `ProjectTo` throws `DimensionMismatch: array with ndims(x) == 1 > 0 cannot have dx::Number`. The forward pass and the ForwardDiff example below it are unaffected.

2. **MTK problems on `EnsembleGPUKernel`.** This is worth flagging: **#375 is closed but the bug is live.** `EnsembleGPUKernel` moves the vector of problems to the device, which requires the whole `ImmutableODEProblem` to be `isbitstype`. An MTK-generated `ODEFunction` never is. Probing `make_prob_compatible` directly:

   ```
   === MTK, split=false, default init      isbitstype=false
         BAD f.observed :: ObservedFunctionCache{System, Nothing}
         BAD f.sys :: System
         BAD f.initialization_data :: Union{Nothing, OverrideInitData}
         BAD f.nlstep_data :: Union{Nothing, ODENLStepData}
   === MTK, split=false, build_initializeprob=false   isbitstype=false
         (same four fields)
   === hand-written baseline               isbitstype=true
   ```

   Making `u0` and `p` static is necessary but not sufficient, and `build_initializeprob = false` does not help. The fix belongs in the device conversion: strip `sys`/`observed`/`initialization_data`/`nlstep_data` at the `adapt` boundary while leaving the host-side `probs` intact, so `build_solution` keeps working and symbolic indexing on the result still resolves. That is verifiable locally with `isbitstype`, without a GPU. Happy to do it as a follow-up.

Marking these unevaluated is a deliberate trade. A red docs build means nothing deploys at all, which is what left users reading a 2023 page in the first place. If you would rather keep them executing and fix the packages first, those two hunks can be dropped.

### `README.md`

Fixes the last remaining three-argument `prob_func` in the repo, which the SciMLBase v3 migration (90813db) skipped. Also drops a stale "expected to be completed by the summer of 2025".

## Verification

The MTK rewrite was run locally against the exact versions CI resolves: `mtkcompile`, problem construction, CPU `solve`, `setsym_oop`, `remake`, and symbolic indexing all pass, with static `isbits` `u0`/`p` and no deprecation warnings.

I could not verify the GPU paths locally — no CUDA on this machine. The pocl/OpenCL fallback is not usable as a substitute: it dies on `ForwardDiff.Dual` fills (`clEnqueueMemFillINTEL` → `CL_INVALID_VALUE`), and with pocl loaded any thrown exception wedges Julia's stack unwinder indefinitely. `gpu-docs` on the V100 runner is the real check for this PR.

## Not addressed here

The same CI run has a separate, unrelated test failure worth its own issue:

```
MethodError: no method matching findall_events!(::CuArray{Float32,1}, ::CuArray{Float32,1})
```

Separately, SciMLBase currently gives users a bare `MethodError` for the old three-argument signature. An arity check in the `EnsembleProblem` constructor pointing at `EnsembleContext` would turn every stale tutorial and blog post on the internet into a one-line fix rather than a confusing gensym error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)