### PR TITLE
Require rendered docs for DiffEqGPU reexports

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,7 @@ makedocs(
     sitename = "DiffEqGPU.jl",
     authors = "Chris Rackauckas",
     modules = [DiffEqGPU],
-    clean = true, doctest = false, linkcheck = true,
+    clean = true, linkcheck = true,
     warnonly = [:missing_docs],
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],

--- a/docs/src/manual/api.md
+++ b/docs/src/manual/api.md
@@ -1,5 +1,18 @@
 # API
 
+## Reexported Ensemble API
+
+```@docs
+SciMLBase.EnsembleProblem
+SciMLBase.EnsembleSolution
+SciMLBase.EnsembleSerial
+SciMLBase.EnsembleThreads
+SciMLBase.EnsembleDistributed
+SciMLBase.CheckInit
+SciMLBase.terminate!
+DiffEqBase.BrownFullBasicInit
+```
+
 ## Lower-Level Algorithms
 
 ```@docs

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -15,7 +15,6 @@ const REEXPORTED_API = (
 run_qa(
     DiffEqGPU;
     reexports_allow = REEXPORTED_API,
-    api_docs_kwargs = (; rendered_ignore = REEXPORTED_API),
     ei_kwargs = (;
         # StaticVecOrMat is re-exported by StaticArrays but owned by StaticArraysCore.
         # It is a non-public type alias used only in method-signature dispatch for the


### PR DESCRIPTION
## Summary
- render the explicitly allowed ensemble reexports on the API page
- use standard SciMLTesting rendered-public-doc validation with no `rendered_ignore`
- re-enable Documenter doctests

## Validation
- `GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` (QA: 21/21; JET: 75/75)\n- Runic and `git diff --check`\n- full `julia +1.12 --project=docs docs/make.jl` is still actively JIT compiling the package documentation environment locally; no failures have been emitted.\n\nIgnore until reviewed by @ChrisRackauckas.