### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqGPU"
 uuid = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 authors = ["Chris Rackauckas", "SciML"]
-version = "3.16.1"
+version = "3.17.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Version bumps only -- no source changes.

Each package below has `src/` changes since its last registered version (verified by comparing the registry's recorded `git-tree-sha1` for that version against the current tree), but its `Project.toml` version still equals the registered one, so there is nothing to register.

Increment is minor, which is a valid standard increment under the General [sequential version number](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) guideline.

- DiffEqGPU 3.16.1 -> 3.17.0