### PR TITLE
Drop stale [compat] majors older than one year

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -50,7 +50,7 @@ oneAPIExt = ["oneAPI"]
 [compat]
 AMDGPU = "2"
 Adapt = "4"
-CUDA = "5, 6"
+CUDA = "6"
 ChainRulesCore = "1"
 CommonSolve = "0.2.6"
 DifferentiationInterface = "0.7.18"


### PR DESCRIPTION
Drop `[compat]` majors whose first General-registry release is older than one year, and keep remaining floors on the latest major.

Policy: SciML minima sit on the latest majors. Extra majors first registered before 2025-08-26 are dropped. Majors first registered after that cutoff are kept (currently: OrdinaryDiffEqCore 4, LinearSolve 4, DiffEqDevTools 3). `julia` and stdlib entries are untouched.

| file | dep | before | after |
|---|---|---|---|
| `Project.toml` | `CUDA` | `5, 6` | `6` |

OrdinaryDiffEqCore 4 / LinearSolve 4 / DiffEqDevTools 3 are kept where present because they were not in General a year ago.



This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
