### PR TITLE
Fix EnsembleGPUArray continuous callbacks on CUDA

### DIFF
--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -1,6 +1,7 @@
 module CUDAExt
-using CUDA: CUDA, CUDABackend
+using CUDA: CUDA, CuArray, CUDABackend
 import DiffEqGPU
+import DiffEqBase: findall_events!
 
 function DiffEqGPU.EnsembleGPUArray(cpu_offload::Float64)
     return DiffEqGPU.EnsembleGPUArray(CUDABackend(), cpu_offload)
@@ -11,6 +12,16 @@ DiffEqGPU.maybe_prefer_blocks(::CUDABackend) = CUDABackend(; prefer_blocks = tru
 function DiffEqGPU.lufact!(::CUDABackend, W)
     CUDA.CUBLAS.getrf_strided_batched!(W, false)
     return nothing
+end
+
+# DiffEqBase only defines `findall_events!` for CPU arrays, but
+# `EnsembleGPUArray` keeps callback caches on the GPU.
+function findall_events!(next_sign::CuArray, prev_sign::CuArray)
+    next_cpu = Array(next_sign)
+    prev_cpu = Array(prev_sign)
+    event_occurred = findall_events!(next_cpu, prev_cpu)
+    copyto!(next_sign, next_cpu)
+    return event_occurred
 end
 
 end


### PR DESCRIPTION
## Summary
- Add a `findall_events!` overload for `CuArray` in `CUDAExt` so `VectorContinuousCallback` event detection works with GPU-resident callback caches.
- Fixes the `EnsembleGPUArray` test error introduced by newer DiffEqBase callback APIs that only define `findall_events!` for CPU `Array`/`SubArray`.

## Root cause
`EnsembleGPUArray` solves vectorized problems with `CuArray` state and callback caches. DiffEqBase's `check_event_occurrence_upto` calls `findall_events!(top_condition, bottom_sign)` on those caches, but no GPU method exists.

## Test plan
- [x] Verified locally that the failing continuous-callback `EnsembleGPUArray` path no longer throws `MethodError: no method matching findall_events!(::CuArray, ::CuArray)`.
- [ ] CUDA Tests CI on this PR.

Made with [Cursor](https://cursor.com)