### PR TITLE
Support structured MTKParameters in GPU DAE solves

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,6 +36,7 @@ AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839"
 OpenCL = "08131aa3-fb12-5dee-8b74-c09406e224a2"
 oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
 
@@ -44,6 +45,7 @@ AMDGPUExt = ["AMDGPU"]
 CUDAExt = ["CUDA"]
 JLArraysExt = ["JLArrays"]
 MetalExt = ["Metal"]
+ModelingToolkitBaseExt = ["ModelingToolkitBase"]
 OpenCLExt = ["OpenCL"]
 oneAPIExt = ["oneAPI"]
 
@@ -64,6 +66,7 @@ KernelAbstractions = "0.9.38"
 LinearAlgebra = "1"
 LinearSolve = "5.2"
 Metal = "1"
+ModelingToolkitBase = "1"
 MuladdMacro = "0.2.4"
 OpenCL = "0.10"
 Parameters = "0.13"

--- a/ext/ModelingToolkitBaseExt.jl
+++ b/ext/ModelingToolkitBaseExt.jl
@@ -1,0 +1,30 @@
+module ModelingToolkitBaseExt
+
+using ModelingToolkitBase: MTKParameters
+using StaticArraysCore: SArray, StaticArray
+import DiffEqGPU
+
+function static_parameter_storage(x::StaticArray)
+    values = map(static_parameter_storage, x)
+    return SArray{Tuple{size(x)...}}(values)
+end
+function static_parameter_storage(x::Array)
+    values = map(static_parameter_storage, x)
+    return SArray{Tuple{size(x)...}}(values)
+end
+static_parameter_storage(x::Tuple) = map(static_parameter_storage, x)
+static_parameter_storage(x::NamedTuple) = map(static_parameter_storage, x)
+static_parameter_storage(x) = x
+
+function DiffEqGPU.make_parameter_compatible(p::MTKParameters)
+    return MTKParameters(
+        static_parameter_storage(p.tunable),
+        static_parameter_storage(p.initials),
+        static_parameter_storage(p.discrete),
+        static_parameter_storage(p.constant),
+        static_parameter_storage(p.nonnumeric),
+        static_parameter_storage(p.caches)
+    )
+end
+
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,18 +6,24 @@ end
 diffeqgpunorm(u::ForwardDiff.Dual, t) = abs(ForwardDiff.value(u))
 
 """
-    make_prob_compatible(prob)
+    make_prob_compatible(prob; nlsolve_alg = SimpleTrustRegion(), abstol = 1e-6,
+        reltol = 1e-6)
 
 Prepare a problem for the lower-level `EnsembleGPUKernel` interface.
 
-For an `ODEProblem`, this converts the problem to an immutable representation and adapts
-mass-matrix data when needed. Other problem-like values are returned unchanged. The
-resulting problem must still satisfy the selected backend's GPU-compatibility requirements.
+For an `ODEProblem`, this solves any initialization problem on the host, removes the
+initialization metadata, converts the problem to an immutable representation, and adapts
+parameter and mass-matrix storage when needed. Other problem-like values are returned
+unchanged. The resulting problem must still satisfy the selected backend's
+GPU-compatibility requirements.
 
 # Arguments
 
   - `prob`: an `ODEProblem` or another problem value accepted by the lower-level ensemble
     interface.
+  - `nlsolve_alg`: nonlinear solver used for problem initialization.
+  - `abstol`: absolute tolerance used for problem initialization.
+  - `reltol`: relative tolerance used for problem initialization.
 
 # Returns
 
@@ -33,10 +39,45 @@ prob = ODEProblem{false}(f, SVector(1.0f0), (0.0f0, 1.0f0), SVector(1.0f0))
 gpu_prob = DiffEqGPU.make_prob_compatible(prob)
 ```
 """
-make_prob_compatible(prob) = prob
+make_prob_compatible(prob; kwargs...) = prob
+make_parameter_compatible(p) = p
 
-function make_prob_compatible(prob::T) where {T <: ODEProblem}
+function make_prob_compatible(
+        prob::T; nlsolve_alg = SimpleTrustRegion(), abstol = 1.0e-6,
+        reltol = 1.0e-6
+    ) where {T <: ODEProblem}
+    if SciMLBase.has_initialization_data(prob.f)
+        return _initialized_problem_compatible(prob, nlsolve_alg, abstol, reltol)
+    end
+
+    prob = remake(prob; p = make_parameter_compatible(prob.p))
     return convert(ImmutableODEProblem, _maybe_convert_mass_matrix(prob))
+end
+
+function _initialized_problem_compatible(prob, nlsolve_alg, abstol, reltol)
+    u0, p, success = gpu_initialization_solve(prob, nlsolve_alg, abstol, reltol)
+    success || error("Initialization failed while preparing an ODEProblem for EnsembleGPUKernel.")
+
+    oldf = prob.f
+    mass_matrix = _compatible_mass_matrix(oldf.mass_matrix, length(u0))
+    newf = SciMLBase.ODEFunction{
+        SciMLBase.isinplace(oldf), SciMLBase.specialization(oldf),
+    }(
+        oldf.f;
+        jac = oldf.jac,
+        mass_matrix,
+        initialization_data = nothing
+    )
+    static_u0 = StaticArrays.SVector{length(u0)}(u0)
+    static_p = make_parameter_compatible(p)
+    return ImmutableODEProblem(
+        newf, static_u0, prob.tspan, static_p, prob.problem_type; prob.kwargs...
+    )
+end
+
+function _compatible_mass_matrix(mm, N)
+    (mm isa StaticArrays.StaticArray || mm === LinearAlgebra.I) && return mm
+    return StaticArrays.SMatrix{N, N}(mm)
 end
 
 function _maybe_convert_mass_matrix(prob)

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
@@ -11,6 +11,9 @@ if GROUP == "CUDA"
 elseif GROUP == "AMDGPU"
     using AMDGPU
     const backend = ROCBackend()
+elseif GROUP == "JLArrays"
+    using JLArrays
+    const backend = JLBackend()
 else
     const backend = CPU()
 end
@@ -106,24 +109,68 @@ end
 end
 
 # ============================================================================
-# Test 2: ModelingToolkit cartesian pendulum DAE with initialization
+# Test 2: Structured ModelingToolkit parameter storage
 # ============================================================================
 
-# NOTE: This testset is currently broken across all backends.
-#
-# 1. GPU side: ModelingToolkit problems with initialization data contain
-#    MTKParameters whose `Vector` fields can't be stored inline in CuArrays
-#    (https://github.com/SciML/DiffEqGPU.jl/issues/375).
-#
-# 2. CPU side: under the SciMLBase v3 / MTK 11.22+ / ChainRulesCore stack,
-#    constructing `ODEProblem(pendulum, …)` for a DAE with initialization
-#    errors with `type Nothing has no field oop_reconstruct_u0_p` from
-#    `MTKChainRulesCoreExt`. This is upstream MTK behaviour, not a
-#    DiffEqGPU regression.
-#
-# Until both are resolved we mark the whole testset as broken instead of
-# running it. Re-enable the original body once issue #375 is fixed and the
-# MTK CRCExt path is stable.
+@testset "Structured MTKParameters storage" begin
+    p = MTKParameters(
+        [1.0, 2.0],
+        ([3.0], (offset = [4.0],)),
+        (mode = ([5.0],),),
+        (6.0, MVector(7.0)),
+        (),
+        ([8.0],)
+    )
+    compatible_p = DiffEqGPU.make_parameter_compatible(p)
+
+    @test compatible_p.tunable isa SVector
+    @test compatible_p.initials[1] isa SVector
+    @test compatible_p.initials[2].offset isa SVector
+    @test compatible_p.discrete.mode[1] isa SVector
+    @test compatible_p.constant[2] isa SVector
+    @test compatible_p.caches[1] isa SVector
+    @test isbitstype(typeof(compatible_p))
+end
+
+# ============================================================================
+# Test 3: ModelingToolkit cartesian pendulum DAE with initialization
+# ============================================================================
+
 @testset "MTK Pendulum DAE with initialization" begin
-    @test_broken false
+    @parameters g = 9.81 L = 1.0
+    @variables px(t) py(t) [state_priority = 10] pλ(t)
+
+    eqs = [
+        D(D(px)) ~ pλ * px / L
+        D(D(py)) ~ pλ * py / L - g
+        px^2 + py^2 ~ L^2
+    ]
+
+    @mtkcompile pendulum = ODESystem(eqs, t, [px, py, pλ], [g, L])
+
+    mtk_prob = ODEProblem(
+        pendulum, [py => 0.99], (0.0, 1.0),
+        guesses = [pλ => 0.0, px => 0.1, D(px) => 0.0, D(py) => 0.0]
+    )
+
+    @test SciMLBase.has_initialization_data(mtk_prob.f)
+    @test mtk_prob.f.mass_matrix !== LinearAlgebra.I
+
+    compatible_prob = DiffEqGPU.make_prob_compatible(mtk_prob)
+    @test isbitstype(typeof(compatible_prob))
+    @test !SciMLBase.has_initialization_data(compatible_prob.f)
+
+    ref_sol = solve(mtk_prob, Rodas5P())
+    @test SciMLBase.successful_retcode(ref_sol)
+
+    monteprob_mtk = EnsembleProblem(mtk_prob, safetycopy = false)
+    sol_mtk = solve(
+        monteprob_mtk, GPURodas5P(), EnsembleGPUKernel(backend),
+        trajectories = 2,
+        dt = 0.01,
+        adaptive = false
+    )
+    @test length(sol_mtk.u) == 2
+    @test !any(isnan, sol_mtk.u[1].u[end])
+    @test norm(sol_mtk.u[1].u[end] - ref_sol.u[end]) < 1.0
 end


### PR DESCRIPTION
## Summary

- add a ModelingToolkitBase extension that recursively converts all six `MTKParameters` storage portions to immutable static storage
- solve ModelingToolkit initialization problems on the host, then remove initialization metadata before adapting problems to a GPU backend
- restore the initialized pendulum DAE regression and add explicit JLArrays and mixed-storage coverage

This follows up on #375 now that `MTKParameters` is a structured container rather than a plain array.

## Testing

- JLArrays focused DAE suite: 30/30 passed, including the initialized MTK pendulum
- structured `MTKParameters` conversion: 7/7 passed, plus a mutable-static-array smoke test
- public interface tests: passed
- QA: 21/21 passed
- JET: 75/75 passed
- Runic and `git diff --check`: passed
- CUDA direct DAE solvers: 15/15 passed; structured conversion: 7/7 passed

On the local Pascal GTX 1050 Ti, the generated MTK pendulum kernel reaches CUDA compilation with inline `MTKParameters{SVector,...}` storage, then encounters the known CUDA driver code 801 cubin-load limitation on this machine.
