### PR TITLE
Run DAE initialization in GPU kernels

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,6 +36,7 @@ AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839"
 OpenCL = "08131aa3-fb12-5dee-8b74-c09406e224a2"
 oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
 
@@ -44,6 +45,7 @@ AMDGPUExt = ["AMDGPU"]
 CUDAExt = ["CUDA"]
 JLArraysExt = ["JLArrays"]
 MetalExt = ["Metal"]
+ModelingToolkitBaseExt = ["ModelingToolkitBase"]
 OpenCLExt = ["OpenCL"]
 oneAPIExt = ["oneAPI"]
 
@@ -64,6 +66,7 @@ KernelAbstractions = "0.9.38"
 LinearAlgebra = "1"
 LinearSolve = "5.2"
 Metal = "1"
+ModelingToolkitBase = "1"
 MuladdMacro = "0.2.4"
 OpenCL = "0.10"
 Parameters = "0.13"

--- a/ext/ModelingToolkitBaseExt.jl
+++ b/ext/ModelingToolkitBaseExt.jl
@@ -1,8 +1,9 @@
 module ModelingToolkitBaseExt
 
 using ModelingToolkitBase: MTKParameters
-using StaticArraysCore: SArray, StaticArray
+using StaticArraysCore: SArray, StaticArray, SVector
 import DiffEqGPU
+import SciMLBase
 
 function static_parameter_storage(x::StaticArray)
     values = map(static_parameter_storage, x)
@@ -25,6 +26,199 @@ function DiffEqGPU.make_parameter_compatible(p::MTKParameters)
         static_parameter_storage(p.nonnumeric),
         static_parameter_storage(p.caches)
     )
+end
+
+struct InitializationSourceIndex
+    index::Int
+end
+
+struct InitializationStructureRecipe{T, R}
+    values::R
+end
+
+struct InitializationStateMap{R}
+    recipe::R
+end
+
+struct InitializationParameterRecipe{T, I, D, C}
+    tunable::T
+    initials::I
+    discrete::D
+    constant::C
+end
+
+struct InitializationParameterMap{R}
+    recipe::R
+end
+
+function numeric_values(x::Number, ::Type{T}) where {T}
+    return SVector{1, T}(x)
+end
+numeric_values(x::StaticArray, ::Type{T}) where {T} = numeric_values(Tuple(x), T)
+numeric_values(x::NamedTuple, ::Type{T}) where {T} = numeric_values(values(x), T)
+numeric_values(::Tuple{}, ::Type{T}) where {T} = SVector{0, T}()
+function numeric_values(x::Tuple, ::Type{T}) where {T}
+    return vcat(numeric_values(first(x), T), numeric_values(Base.tail(x), T))
+end
+function numeric_values(x, ::Type{T}) where {T}
+    values = ntuple(i -> getfield(x, i), fieldcount(typeof(x)))
+    return numeric_values(values, T)
+end
+
+function initialization_sources(valp)
+    u = SciMLBase.state_values(valp)
+    p = SciMLBase.parameter_values(valp)
+    T = eltype(u)
+    return vcat(
+        numeric_values(u, T), numeric_values(p.tunable, T),
+        numeric_values(p.initials, T), numeric_values(p.discrete, T),
+        numeric_values(p.constant, T)
+    )
+end
+
+gather_initialization_value(index::InitializationSourceIndex, sources) =
+    sources[index.index]
+gather_initialization_value(recipe::StaticArray, sources) =
+    map(Base.Fix2(gather_initialization_value, sources), recipe)
+gather_initialization_value(recipe::Tuple, sources) =
+    map(Base.Fix2(gather_initialization_value, sources), recipe)
+gather_initialization_value(recipe::NamedTuple, sources) =
+    map(Base.Fix2(gather_initialization_value, sources), recipe)
+function gather_initialization_value(
+        recipe::InitializationStructureRecipe{T}, sources
+    ) where {T}
+    values = map(Base.Fix2(gather_initialization_value, sources), recipe.values)
+    return T(values...)
+end
+
+function (map::InitializationStateMap)(sol)
+    return gather_initialization_value(map.recipe, initialization_sources(sol))
+end
+
+function (map::InitializationParameterMap)(prob, sol)
+    sources = vcat(initialization_sources(prob), initialization_sources(sol))
+    recipe = map.recipe
+    p = SciMLBase.parameter_values(prob)
+    return MTKParameters(
+        gather_initialization_value(recipe.tunable, sources),
+        gather_initialization_value(recipe.initials, sources),
+        gather_initialization_value(recipe.discrete, sources),
+        gather_initialization_value(recipe.constant, sources),
+        p.nonnumeric,
+        p.caches
+    )
+end
+
+function next_tag!(tags)
+    tag = -1.234567890123456e200 * (length(tags) + 1)
+    push!(tags, tag)
+    return tag
+end
+
+tag_numeric(x::Number, tags) = next_tag!(tags)
+tag_numeric(x::AbstractArray, tags) = map(Base.Fix2(tag_numeric, tags), x)
+tag_numeric(x::Tuple, tags) = map(Base.Fix2(tag_numeric, tags), x)
+tag_numeric(x::NamedTuple, tags) = map(Base.Fix2(tag_numeric, tags), x)
+function tag_numeric(x, tags)
+    values = ntuple(i -> tag_numeric(getfield(x, i), tags), fieldcount(typeof(x)))
+    return typeof(x)(values...)
+end
+
+function tag_parameters(p::MTKParameters, tags)
+    return MTKParameters(
+        tag_numeric(p.tunable, tags),
+        tag_numeric(p.initials, tags),
+        tag_numeric(p.discrete, tags),
+        tag_numeric(p.constant, tags),
+        p.nonnumeric,
+        p.caches
+    )
+end
+
+function tag_initialization_problem(prob::SciMLBase.NonlinearLeastSquaresProblem, tags)
+    return SciMLBase.NonlinearLeastSquaresProblem{SciMLBase.isinplace(prob)}(
+        prob.f,
+        tag_numeric(prob.u0, tags),
+        tag_parameters(prob.p, tags);
+        lb = prob.lb,
+        ub = prob.ub,
+        prob.kwargs...
+    )
+end
+
+function tag_initialization_problem(
+        prob::Union{SciMLBase.NonlinearProblem, SciMLBase.ImmutableNonlinearProblem}, tags
+    )
+    return SciMLBase.ImmutableNonlinearProblem{SciMLBase.isinplace(prob)}(
+        prob.f,
+        tag_numeric(prob.u0, tags),
+        tag_parameters(prob.p, tags),
+        prob.problem_type;
+        prob.kwargs...
+    )
+end
+
+function tag_ode_problem(prob, tags)
+    return SciMLBase.ImmutableODEProblem(
+        prob.f,
+        tag_numeric(prob.u0, tags),
+        prob.tspan,
+        tag_parameters(prob.p, tags),
+        prob.problem_type;
+        prob.kwargs...
+    )
+end
+
+function source_recipe(x::Number, tags)
+    index = findfirst(Base.Fix2(isequal, x), tags)
+    index === nothing && error(
+        "ModelingToolkit initialization maps must copy numeric values from the ODE or initialization problem."
+    )
+    return InitializationSourceIndex(index)
+end
+function source_recipe(x::AbstractArray, tags)
+    values = map(Base.Fix2(source_recipe, tags), x)
+    return SArray{Tuple{size(x)...}}(values)
+end
+source_recipe(x::Tuple, tags) = map(Base.Fix2(source_recipe, tags), x)
+source_recipe(x::NamedTuple, tags) = map(Base.Fix2(source_recipe, tags), x)
+function source_recipe(x, tags)
+    values = ntuple(i -> source_recipe(getfield(x, i), tags), fieldcount(typeof(x)))
+    return InitializationStructureRecipe{typeof(x)}(values)
+end
+
+function make_state_map(initprob, map)
+    map === nothing && return nothing
+    # Evaluate the host-only MTK map on unique numeric tags, then retain only the
+    # resulting device-compatible gather indices.
+    tags = Float64[]
+    tagged_initprob = tag_initialization_problem(initprob, tags)
+    return InitializationStateMap(source_recipe(map(tagged_initprob), tags))
+end
+
+function make_parameter_map(prob, initprob, map)
+    map === nothing && return nothing
+    # Parameter maps may select from both the ODE problem and nonlinear solution.
+    tags = Float64[]
+    tagged_prob = tag_ode_problem(prob, tags)
+    tagged_initprob = tag_initialization_problem(initprob, tags)
+    p = map(tagged_prob, tagged_initprob)
+    p isa MTKParameters || error(
+        "ModelingToolkit initialization parameter maps must return `MTKParameters`."
+    )
+    recipe = InitializationParameterRecipe(
+        source_recipe(p.tunable, tags),
+        source_recipe(p.initials, tags),
+        source_recipe(p.discrete, tags),
+        source_recipe(p.constant, tags)
+    )
+    return InitializationParameterMap(recipe)
+end
+
+function DiffEqGPU.make_initialization_maps_compatible(
+        prob, initprob, umap, pmap, ::MTKParameters
+    )
+    return make_state_map(initprob, umap), make_parameter_map(prob, initprob, pmap)
 end
 
 end

--- a/ext/ModelingToolkitBaseExt.jl
+++ b/ext/ModelingToolkitBaseExt.jl
@@ -1,0 +1,30 @@
+module ModelingToolkitBaseExt
+
+using ModelingToolkitBase: MTKParameters
+using StaticArraysCore: SArray, StaticArray
+import DiffEqGPU
+
+function static_parameter_storage(x::StaticArray)
+    values = map(static_parameter_storage, x)
+    return SArray{Tuple{size(x)...}}(values)
+end
+function static_parameter_storage(x::Array)
+    values = map(static_parameter_storage, x)
+    return SArray{Tuple{size(x)...}}(values)
+end
+static_parameter_storage(x::Tuple) = map(static_parameter_storage, x)
+static_parameter_storage(x::NamedTuple) = map(static_parameter_storage, x)
+static_parameter_storage(x) = x
+
+function DiffEqGPU.make_parameter_compatible(p::MTKParameters)
+    return MTKParameters(
+        static_parameter_storage(p.tunable),
+        static_parameter_storage(p.initials),
+        static_parameter_storage(p.discrete),
+        static_parameter_storage(p.constant),
+        static_parameter_storage(p.nonnumeric),
+        static_parameter_storage(p.caches)
+    )
+end
+
+end

--- a/src/ensemblegpukernel/kernels.jl
+++ b/src/ensemblegpukernel/kernels.jl
@@ -41,7 +41,7 @@
             end
         else
             @inbounds ts[integ.step_idx] = prob.tspan[1]
-            @inbounds us[integ.step_idx] = prob.u0
+            @inbounds us[integ.step_idx] = u0
         end
 
         integ.step_idx += 1

--- a/src/ensemblegpukernel/nlsolve/initialization.jl
+++ b/src/ensemblegpukernel/nlsolve/initialization.jl
@@ -32,7 +32,7 @@
     sol = SciMLBase.solve(initprob, alg; abstol, reltol)
 
     # Extract results — initialization must succeed
-    if !SciMLBase.successful_retcode(sol)
+    if !gpu_initialization_success(initprob, sol, abstol)
         return u0, p, false
     end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,25 +6,20 @@ end
 diffeqgpunorm(u::ForwardDiff.Dual, t) = abs(ForwardDiff.value(u))
 
 """
-    make_prob_compatible(prob; nlsolve_alg = SimpleTrustRegion(), abstol = 1e-6,
-        reltol = 1e-6)
+    make_prob_compatible(prob)
 
 Prepare a problem for the lower-level `EnsembleGPUKernel` interface.
 
-For an `ODEProblem`, this solves any initialization problem on the host, removes the
-initialization metadata, converts the problem to an immutable representation, and adapts
-parameter and mass-matrix storage when needed. Other problem-like values are returned
-unchanged. The resulting problem must still satisfy the selected backend's
+For an `ODEProblem`, this updates any initialization problem on the host, converts the
+initialization problem and its maps to immutable static representations for device-side
+solving, and adapts parameter and mass-matrix storage. Other problem-like values are
+returned unchanged. The resulting problem must still satisfy the selected backend's
 GPU-compatibility requirements.
 
 # Arguments
 
   - `prob`: an `ODEProblem` or another problem value accepted by the lower-level ensemble
     interface.
-  - `nlsolve_alg`: nonlinear solver used for problem initialization.
-  - `abstol`: absolute tolerance used for problem initialization.
-  - `reltol`: relative tolerance used for problem initialization.
-
 # Returns
 
 An immutable, backend-compatible representation for ODE problems, or `prob` unchanged for
@@ -42,36 +37,143 @@ gpu_prob = DiffEqGPU.make_prob_compatible(prob)
 make_prob_compatible(prob; kwargs...) = prob
 make_parameter_compatible(p) = p
 
-function make_prob_compatible(
-        prob::T; nlsolve_alg = SimpleTrustRegion(), abstol = 1.0e-6,
-        reltol = 1.0e-6
-    ) where {T <: ODEProblem}
+function make_prob_compatible(prob::T) where {T <: ODEProblem}
     if SciMLBase.has_initialization_data(prob.f)
-        return _initialized_problem_compatible(prob, nlsolve_alg, abstol, reltol)
+        return _initialized_problem_compatible(prob)
     end
 
     prob = remake(prob; p = make_parameter_compatible(prob.p))
     return convert(ImmutableODEProblem, _maybe_convert_mass_matrix(prob))
 end
 
-function _initialized_problem_compatible(prob, nlsolve_alg, abstol, reltol)
-    u0, p, success = gpu_initialization_solve(prob, nlsolve_alg, abstol, reltol)
-    success || error("Initialization failed while preparing an ODEProblem for EnsembleGPUKernel.")
-
+function _initialized_problem_compatible(prob)
     oldf = prob.f
-    mass_matrix = _compatible_mass_matrix(oldf.mass_matrix, length(u0))
+    initdata = oldf.initialization_data
+    initprob = initdata.initializeprob
+    if initdata.update_initializeprob! !== nothing
+        initprob = if initdata.is_update_oop === Val(true)
+            initdata.update_initializeprob!(initprob, prob)
+        else
+            initdata.update_initializeprob!(initprob, prob)
+            initprob
+        end
+    end
+    initprobmap, initprobpmap = make_initialization_maps_compatible(
+        prob, initprob, initdata.initializeprobmap, initdata.initializeprobpmap, prob.p
+    )
+    compatible_initdata = SciMLBase.OverrideInitData(
+        make_nonlinear_problem_compatible(initprob), nothing, initprobmap, initprobpmap,
+        nothing, Val(false)
+    )
+
+    mass_matrix = _compatible_mass_matrix(oldf.mass_matrix, length(prob.u0))
     newf = SciMLBase.ODEFunction{
         SciMLBase.isinplace(oldf), SciMLBase.specialization(oldf),
     }(
         oldf.f;
         jac = oldf.jac,
         mass_matrix,
-        initialization_data = nothing
+        initialization_data = compatible_initdata
     )
-    static_u0 = StaticArrays.SVector{length(u0)}(u0)
-    static_p = make_parameter_compatible(p)
+    static_u0 = make_static_storage(prob.u0)
+    static_p = make_parameter_compatible(prob.p)
     return ImmutableODEProblem(
         newf, static_u0, prob.tspan, static_p, prob.problem_type; prob.kwargs...
+    )
+end
+
+make_initialization_maps_compatible(prob, initprob, umap, pmap, p) = (umap, pmap)
+
+make_static_storage(x::StaticArrays.StaticArray) =
+    StaticArrays.SArray{Tuple{size(x)...}}(map(make_static_storage, x))
+make_static_storage(x::Array) =
+    StaticArrays.SArray{Tuple{size(x)...}}(map(make_static_storage, x))
+make_static_storage(x::Tuple) = map(make_static_storage, x)
+make_static_storage(x::NamedTuple) = map(make_static_storage, x)
+make_static_storage(x) = x
+
+function make_nonlinear_function_compatible(oldf)
+    return SciMLBase.NonlinearFunction{
+        false, SciMLBase.FullSpecialize,
+    }(
+        oldf.f;
+        resid_prototype = make_static_storage(oldf.resid_prototype)
+    )
+end
+
+struct GPUInitializationFunction{F, U, R, P}
+    f::F
+    reference_u0::U
+    residual_indices::R
+    pinned_indices::P
+end
+
+function (f::GPUInitializationFunction)(u, p)
+    residual = f.f(u, p)
+    selected = map(i -> residual[i], f.residual_indices)
+    pinned = map(i -> u[i] - f.reference_u0[i], f.pinned_indices)
+    return StaticArrays.SVector((selected..., pinned...))
+end
+
+@inline function gpu_initialization_success(initprob, sol, abstol)
+    SciMLBase.successful_retcode(sol) || return false
+    initprob.f.f isa GPUInitializationFunction || return true
+    residual = initprob.f.f.f(sol.u, initprob.p)
+    return LinearAlgebra.norm(residual) <= abstol
+end
+
+function independent_initialization_indices(f, u0, p)
+    # StaticArrays' rectangular least-squares factorization allocates. Select a square
+    # independent constraint set and pin only the free directions to their supplied
+    # guesses; `gpu_initialization_success` still checks every original residual.
+    jac = Matrix(ForwardDiff.jacobian(Base.Fix2(f, p), u0))
+    jac_rank = LinearAlgebra.rank(jac)
+    jac_rank == 0 && return (), Tuple(eachindex(u0))
+
+    row_factorization = LinearAlgebra.qr(
+        transpose(jac), LinearAlgebra.ColumnNorm()
+    )
+    residual_indices = Tuple(row_factorization.p[1:jac_rank])
+    independent_rows = @view jac[collect(residual_indices), :]
+    column_factorization = LinearAlgebra.qr(
+        independent_rows, LinearAlgebra.ColumnNorm()
+    )
+    independent_columns = column_factorization.p[1:jac_rank]
+    pinned_indices = Tuple(setdiff(eachindex(u0), independent_columns))
+    return residual_indices, pinned_indices
+end
+
+function make_nonlinear_problem_compatible(prob::SciMLBase.NonlinearLeastSquaresProblem)
+    (prob.lb === nothing && prob.ub === nothing) || error(
+        "Bounded nonlinear initialization problems are not supported by EnsembleGPUKernel."
+    )
+    static_u0 = make_static_storage(prob.u0)
+    static_p = make_parameter_compatible(prob.p)
+    compatible_f = make_nonlinear_function_compatible(prob.f)
+    residual_indices, pinned_indices = independent_initialization_indices(
+        compatible_f, static_u0, static_p
+    )
+    square_f = GPUInitializationFunction(
+        compatible_f, static_u0, residual_indices, pinned_indices
+    )
+    nonlinear_f = SciMLBase.NonlinearFunction{false, SciMLBase.FullSpecialize}(
+        square_f; resid_prototype = zero(static_u0)
+    )
+    return SciMLBase.ImmutableNonlinearProblem{false}(
+        nonlinear_f, static_u0, static_p;
+        prob.kwargs...
+    )
+end
+
+function make_nonlinear_problem_compatible(
+        prob::Union{SciMLBase.NonlinearProblem, SciMLBase.ImmutableNonlinearProblem}
+    )
+    return SciMLBase.ImmutableNonlinearProblem{false}(
+        make_nonlinear_function_compatible(prob.f),
+        make_static_storage(prob.u0),
+        make_parameter_compatible(prob.p),
+        prob.problem_type;
+        prob.kwargs...
     )
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,18 +6,24 @@ end
 diffeqgpunorm(u::ForwardDiff.Dual, t) = abs(ForwardDiff.value(u))
 
 """
-    make_prob_compatible(prob)
+    make_prob_compatible(prob; nlsolve_alg = SimpleTrustRegion(), abstol = 1e-6,
+        reltol = 1e-6)
 
 Prepare a problem for the lower-level `EnsembleGPUKernel` interface.
 
-For an `ODEProblem`, this converts the problem to an immutable representation and adapts
-mass-matrix data when needed. Other problem-like values are returned unchanged. The
-resulting problem must still satisfy the selected backend's GPU-compatibility requirements.
+For an `ODEProblem`, this solves any initialization problem on the host, removes the
+initialization metadata, converts the problem to an immutable representation, and adapts
+parameter and mass-matrix storage when needed. Other problem-like values are returned
+unchanged. The resulting problem must still satisfy the selected backend's
+GPU-compatibility requirements.
 
 # Arguments
 
   - `prob`: an `ODEProblem` or another problem value accepted by the lower-level ensemble
     interface.
+  - `nlsolve_alg`: nonlinear solver used for problem initialization.
+  - `abstol`: absolute tolerance used for problem initialization.
+  - `reltol`: relative tolerance used for problem initialization.
 
 # Returns
 
@@ -33,10 +39,45 @@ prob = ODEProblem{false}(f, SVector(1.0f0), (0.0f0, 1.0f0), SVector(1.0f0))
 gpu_prob = DiffEqGPU.make_prob_compatible(prob)
 ```
 """
-make_prob_compatible(prob) = prob
+make_prob_compatible(prob; kwargs...) = prob
+make_parameter_compatible(p) = p
 
-function make_prob_compatible(prob::T) where {T <: ODEProblem}
+function make_prob_compatible(
+        prob::T; nlsolve_alg = SimpleTrustRegion(), abstol = 1.0e-6,
+        reltol = 1.0e-6
+    ) where {T <: ODEProblem}
+    if SciMLBase.has_initialization_data(prob.f)
+        return _initialized_problem_compatible(prob, nlsolve_alg, abstol, reltol)
+    end
+
+    prob = remake(prob; p = make_parameter_compatible(prob.p))
     return convert(ImmutableODEProblem, _maybe_convert_mass_matrix(prob))
+end
+
+function _initialized_problem_compatible(prob, nlsolve_alg, abstol, reltol)
+    u0, p, success = gpu_initialization_solve(prob, nlsolve_alg, abstol, reltol)
+    success || error("Initialization failed while preparing an ODEProblem for EnsembleGPUKernel.")
+
+    oldf = prob.f
+    mass_matrix = _compatible_mass_matrix(oldf.mass_matrix, length(u0))
+    newf = SciMLBase.ODEFunction{
+        SciMLBase.isinplace(oldf), SciMLBase.specialization(oldf),
+    }(
+        oldf.f;
+        jac = oldf.jac,
+        mass_matrix,
+        initialization_data = nothing
+    )
+    static_u0 = StaticArrays.SVector{length(u0)}(u0)
+    static_p = make_parameter_compatible(p)
+    return ImmutableODEProblem(
+        newf, static_u0, prob.tspan, static_p, prob.problem_type; prob.kwargs...
+    )
+end
+
+function _compatible_mass_matrix(mm, N)
+    (mm isa StaticArrays.StaticArray || mm === LinearAlgebra.I) && return mm
+    return StaticArrays.SMatrix{N, N}(mm)
 end
 
 function _maybe_convert_mass_matrix(prob)

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
@@ -11,6 +11,9 @@ if GROUP == "CUDA"
 elseif GROUP == "AMDGPU"
     using AMDGPU
     const backend = ROCBackend()
+elseif GROUP == "JLArrays"
+    using JLArrays
+    const backend = JLBackend()
 else
     const backend = CPU()
 end
@@ -106,24 +109,68 @@ end
 end
 
 # ============================================================================
-# Test 2: ModelingToolkit cartesian pendulum DAE with initialization
+# Test 2: Structured ModelingToolkit parameter storage
 # ============================================================================
 
-# NOTE: This testset is currently broken across all backends.
-#
-# 1. GPU side: ModelingToolkit problems with initialization data contain
-#    MTKParameters whose `Vector` fields can't be stored inline in CuArrays
-#    (https://github.com/SciML/DiffEqGPU.jl/issues/375).
-#
-# 2. CPU side: under the SciMLBase v3 / MTK 11.22+ / ChainRulesCore stack,
-#    constructing `ODEProblem(pendulum, …)` for a DAE with initialization
-#    errors with `type Nothing has no field oop_reconstruct_u0_p` from
-#    `MTKChainRulesCoreExt`. This is upstream MTK behaviour, not a
-#    DiffEqGPU regression.
-#
-# Until both are resolved we mark the whole testset as broken instead of
-# running it. Re-enable the original body once issue #375 is fixed and the
-# MTK CRCExt path is stable.
+@testset "Structured MTKParameters storage" begin
+    p = MTKParameters(
+        [1.0, 2.0],
+        ([3.0], (offset = [4.0],)),
+        (mode = ([5.0],),),
+        (6.0, MVector(7.0)),
+        (),
+        ([8.0],)
+    )
+    compatible_p = DiffEqGPU.make_parameter_compatible(p)
+
+    @test compatible_p.tunable isa SVector
+    @test compatible_p.initials[1] isa SVector
+    @test compatible_p.initials[2].offset isa SVector
+    @test compatible_p.discrete.mode[1] isa SVector
+    @test compatible_p.constant[2] isa SVector
+    @test compatible_p.caches[1] isa SVector
+    @test isbitstype(typeof(compatible_p))
+end
+
+# ============================================================================
+# Test 3: ModelingToolkit cartesian pendulum DAE with initialization
+# ============================================================================
+
 @testset "MTK Pendulum DAE with initialization" begin
-    @test_broken false
+    @parameters g = 9.81 L = 1.0
+    @variables px(t) py(t) [state_priority = 10] pλ(t)
+
+    eqs = [
+        D(D(px)) ~ pλ * px / L
+        D(D(py)) ~ pλ * py / L - g
+        px^2 + py^2 ~ L^2
+    ]
+
+    @mtkcompile pendulum = ODESystem(eqs, t, [px, py, pλ], [g, L])
+
+    mtk_prob = ODEProblem(
+        pendulum, [py => 0.99], (0.0, 1.0),
+        guesses = [pλ => 0.0, px => 0.1, D(px) => 0.0, D(py) => 0.0]
+    )
+
+    @test SciMLBase.has_initialization_data(mtk_prob.f)
+    @test mtk_prob.f.mass_matrix !== LinearAlgebra.I
+
+    compatible_prob = DiffEqGPU.make_prob_compatible(mtk_prob)
+    @test isbitstype(typeof(compatible_prob))
+    @test !SciMLBase.has_initialization_data(compatible_prob.f)
+
+    ref_sol = solve(mtk_prob, Rodas5P())
+    @test SciMLBase.successful_retcode(ref_sol)
+
+    monteprob_mtk = EnsembleProblem(mtk_prob, safetycopy = false)
+    sol_mtk = solve(
+        monteprob_mtk, GPURodas5P(), EnsembleGPUKernel(backend),
+        trajectories = 2,
+        dt = 0.01,
+        adaptive = false
+    )
+    @test length(sol_mtk.u) == 2
+    @test !any(isnan, sol_mtk.u[1].u[end])
+    @test norm(sol_mtk.u[1].u[end] - ref_sol.u[end]) < 1.0
 end

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
@@ -158,7 +158,11 @@ end
 
     compatible_prob = DiffEqGPU.make_prob_compatible(mtk_prob)
     @test isbitstype(typeof(compatible_prob))
-    @test !SciMLBase.has_initialization_data(compatible_prob.f)
+    @test SciMLBase.has_initialization_data(compatible_prob.f)
+    @test isbitstype(typeof(compatible_prob.f.initialization_data.initializeprob))
+    @test compatible_prob.f.initialization_data.initializeprob isa
+        SciMLBase.ImmutableNonlinearProblem
+    @test compatible_prob.u0 == SVector{length(mtk_prob.u0)}(mtk_prob.u0)
 
     ref_sol = solve(mtk_prob, Rodas5P())
     @test SciMLBase.successful_retcode(ref_sol)
@@ -172,5 +176,6 @@ end
     )
     @test length(sol_mtk.u) == 2
     @test !any(isnan, sol_mtk.u[1].u[end])
+    @test norm(sol_mtk.u[1].u[1] - ref_sol.u[1]) < 1.0e-6
     @test norm(sol_mtk.u[1].u[end] - ref_sol.u[end]) < 1.0
 end


### PR DESCRIPTION
## Summary
- preserve and staticize MTK initialization problems for EnsembleGPUKernel
- replace host-only MTK reconstruction closures with isbits gather recipes
- run SimpleTrustRegion initialization per trajectory in the kernel
- square underdetermined static least-squares systems by pinning free directions and validate all original residuals

## Validation
- JLArrays MTK DAE tests pass, including initialized initial-state comparison
- CUDA device compilation reaches cubin generation; this local Pascal setup fails only while loading it with CUDA error 801
- QA passes 21/21
- JET passes 75/75
- public-interface tests pass
- Runic and git diff check pass

Follow-up to #505.