### PR TITLE
Run DAE initialization in GPU kernels

### DIFF
--- a/docs/src/tutorials/modelingtoolkit.md
+++ b/docs/src/tutorials/modelingtoolkit.md
@@ -7,10 +7,12 @@ the simplest set of equations to solve and exploiting things that normally canno
 by hand. Those exact features are also potentially useful for GPU computing, and thus this
 tutorial showcases how to effectively use MTK with DiffEqGPU.jl.
 
-!!! warn
-    
-    This tutorial currently only works for ODEs defined by ModelingToolkit. More work
-    will be required to support DAEs in full. This is work that is ongoing.
+!!! note
+
+    `EnsembleGPUKernel` supports mass-matrix DAEs whose ModelingToolkit initialization
+    problem is square and unbounded. See [DAE initialization](@ref dae_initialization) for
+    an example and the current restrictions. Other DAE formulations may still require
+    `EnsembleGPUArray`.
 
 The core aspect to doing this right is two things. First of all, MTK respects the types
 chosen by the user, and thus in order for GPU kernel generation to work the user needs
@@ -86,15 +88,14 @@ Notice it takes in the vector of values for `[σ, ρ, β]` and spits out the new
 we can build and solve an MTK generated ODE on the GPU using the following:
 
 !!! warning
-    
-    The two blocks below do not currently run. `EnsembleGPUKernel` moves the vector of
-    problems to the device, which requires the whole `ImmutableODEProblem` to be
-    `isbitstype`. An MTK-generated `ODEFunction` never is: `f.sys`, `f.observed`,
-    `f.initialization_data` and `f.nlstep_data` all hold non-inline data, so the
-    conversion fails with `CuArray only supports element types that are allocated
-    inline`. Making `u0` and `p` static, as above, is necessary but not sufficient.
-    See [DiffEqGPU.jl#375](https://github.com/SciML/DiffEqGPU.jl/issues/375). These
-    blocks are left unevaluated until the device conversion strips those fields.
+
+    The generic SymbolicIndexingInterface ensemble transformation below does not
+    currently run inside `EnsembleGPUKernel`: a host-side symbolic setter is not
+    automatically lowered to a device-compatible function. Making `u0` and `p` static
+    is necessary but not sufficient for this workflow. See
+    [DiffEqGPU.jl#375](https://github.com/SciML/DiffEqGPU.jl/issues/375). The DAE path
+    described below is separate: it recognizes ModelingToolkit initialization maps and
+    replaces them with static gather recipes before launching the kernel.
 
 ```julia
 using DiffEqGPU, CUDA
@@ -113,3 +114,60 @@ We can then using symbolic indexing on the result to inspect it:
 ```julia
 [sol.u[i][y] for i in 1:length(sol.u)]
 ```
+
+## [DAE initialization](@id dae_initialization)
+
+ModelingToolkit can generate a nonlinear initialization problem for a mass-matrix DAE.
+`EnsembleGPUKernel` converts that problem to static storage on the host, then solves one
+copy per trajectory inside the GPU kernel with `SimpleTrustRegion` from
+SimpleNonlinearSolve.jl. The resulting consistent state and parameters are used to start
+the ODE solve.
+
+For example, the Cartesian pendulum can be initialized and solved as follows:
+
+```julia
+using CUDA, DiffEqGPU, ModelingToolkit, OrdinaryDiffEq
+using ModelingToolkit: t_nounits as t, D_nounits as D
+
+@parameters g = 9.81 L = 1.0
+@variables px(t) py(t) [state_priority = 10] pλ(t)
+
+eqs = [
+    D(D(px)) ~ pλ * px / L
+    D(D(py)) ~ pλ * py / L - g
+    px^2 + py^2 ~ L^2
+]
+
+@mtkcompile pendulum = ODESystem(eqs, t, [px, py, pλ], [g, L])
+
+prob = ODEProblem(
+    pendulum,
+    [py => 0.99, D(px) => 0.0],
+    (0.0, 1.0);
+    guesses = [pλ => 0.0, px => 0.1, D(py) => 0.0],
+    use_scc = false,
+)
+
+ensemble_prob = EnsembleProblem(prob; safetycopy = false)
+sol = solve(
+    ensemble_prob,
+    GPURodas5P(),
+    EnsembleGPUKernel(CUDA.CUDABackend());
+    trajectories = 10_000,
+    dt = 0.01,
+    adaptive = false,
+)
+```
+
+The current initialization path has the following restrictions:
+
+  - The nonlinear initialization problem must be square. Both underdetermined and
+    overdetermined problems throw an error before the GPU kernel is launched. Supply
+    enough initial conditions and guesses for ModelingToolkit to produce a square system.
+  - Bounds on the nonlinear initialization problem are not supported.
+  - ModelingToolkit's state and parameter initialization maps must copy or restructure
+    numeric values from the ODE and initialization problems. DiffEqGPU traces those maps
+    on the host and stores only static gather recipes in the kernel.
+
+Structured `MTKParameters` storage is converted recursively to static storage, so this
+path does not require `split = false`.

--- a/ext/ModelingToolkitBaseExt.jl
+++ b/ext/ModelingToolkitBaseExt.jl
@@ -1,8 +1,9 @@
 module ModelingToolkitBaseExt
 
 using ModelingToolkitBase: MTKParameters
-using StaticArraysCore: SArray, StaticArray
+using StaticArraysCore: SArray, StaticArray, SVector
 import DiffEqGPU
+import SciMLBase
 
 function static_parameter_storage(x::StaticArray)
     values = map(static_parameter_storage, x)
@@ -25,6 +26,199 @@ function DiffEqGPU.make_parameter_compatible(p::MTKParameters)
         static_parameter_storage(p.nonnumeric),
         static_parameter_storage(p.caches)
     )
+end
+
+struct InitializationSourceIndex
+    index::Int
+end
+
+struct InitializationStructureRecipe{T, R}
+    values::R
+end
+
+struct InitializationStateMap{R}
+    recipe::R
+end
+
+struct InitializationParameterRecipe{T, I, D, C}
+    tunable::T
+    initials::I
+    discrete::D
+    constant::C
+end
+
+struct InitializationParameterMap{R}
+    recipe::R
+end
+
+function numeric_values(x::Number, ::Type{T}) where {T}
+    return SVector{1, T}(x)
+end
+numeric_values(x::StaticArray, ::Type{T}) where {T} = numeric_values(Tuple(x), T)
+numeric_values(x::NamedTuple, ::Type{T}) where {T} = numeric_values(values(x), T)
+numeric_values(::Tuple{}, ::Type{T}) where {T} = SVector{0, T}()
+function numeric_values(x::Tuple, ::Type{T}) where {T}
+    return vcat(numeric_values(first(x), T), numeric_values(Base.tail(x), T))
+end
+function numeric_values(x, ::Type{T}) where {T}
+    values = ntuple(i -> getfield(x, i), fieldcount(typeof(x)))
+    return numeric_values(values, T)
+end
+
+function initialization_sources(valp)
+    u = SciMLBase.state_values(valp)
+    p = SciMLBase.parameter_values(valp)
+    T = eltype(u)
+    return vcat(
+        numeric_values(u, T), numeric_values(p.tunable, T),
+        numeric_values(p.initials, T), numeric_values(p.discrete, T),
+        numeric_values(p.constant, T)
+    )
+end
+
+gather_initialization_value(index::InitializationSourceIndex, sources) =
+    sources[index.index]
+gather_initialization_value(recipe::StaticArray, sources) =
+    map(Base.Fix2(gather_initialization_value, sources), recipe)
+gather_initialization_value(recipe::Tuple, sources) =
+    map(Base.Fix2(gather_initialization_value, sources), recipe)
+gather_initialization_value(recipe::NamedTuple, sources) =
+    map(Base.Fix2(gather_initialization_value, sources), recipe)
+function gather_initialization_value(
+        recipe::InitializationStructureRecipe{T}, sources
+    ) where {T}
+    values = map(Base.Fix2(gather_initialization_value, sources), recipe.values)
+    return T(values...)
+end
+
+function (map::InitializationStateMap)(sol)
+    return gather_initialization_value(map.recipe, initialization_sources(sol))
+end
+
+function (map::InitializationParameterMap)(prob, sol)
+    sources = vcat(initialization_sources(prob), initialization_sources(sol))
+    recipe = map.recipe
+    p = SciMLBase.parameter_values(prob)
+    return MTKParameters(
+        gather_initialization_value(recipe.tunable, sources),
+        gather_initialization_value(recipe.initials, sources),
+        gather_initialization_value(recipe.discrete, sources),
+        gather_initialization_value(recipe.constant, sources),
+        p.nonnumeric,
+        p.caches
+    )
+end
+
+function next_tag!(tags)
+    tag = -1.234567890123456e200 * (length(tags) + 1)
+    push!(tags, tag)
+    return tag
+end
+
+tag_numeric(x::Number, tags) = next_tag!(tags)
+tag_numeric(x::AbstractArray, tags) = map(Base.Fix2(tag_numeric, tags), x)
+tag_numeric(x::Tuple, tags) = map(Base.Fix2(tag_numeric, tags), x)
+tag_numeric(x::NamedTuple, tags) = map(Base.Fix2(tag_numeric, tags), x)
+function tag_numeric(x, tags)
+    values = ntuple(i -> tag_numeric(getfield(x, i), tags), fieldcount(typeof(x)))
+    return typeof(x)(values...)
+end
+
+function tag_parameters(p::MTKParameters, tags)
+    return MTKParameters(
+        tag_numeric(p.tunable, tags),
+        tag_numeric(p.initials, tags),
+        tag_numeric(p.discrete, tags),
+        tag_numeric(p.constant, tags),
+        p.nonnumeric,
+        p.caches
+    )
+end
+
+function tag_initialization_problem(prob::SciMLBase.NonlinearLeastSquaresProblem, tags)
+    return SciMLBase.NonlinearLeastSquaresProblem{SciMLBase.isinplace(prob)}(
+        prob.f,
+        tag_numeric(prob.u0, tags),
+        tag_parameters(prob.p, tags);
+        lb = prob.lb,
+        ub = prob.ub,
+        prob.kwargs...
+    )
+end
+
+function tag_initialization_problem(
+        prob::Union{SciMLBase.NonlinearProblem, SciMLBase.ImmutableNonlinearProblem}, tags
+    )
+    return SciMLBase.ImmutableNonlinearProblem{SciMLBase.isinplace(prob)}(
+        prob.f,
+        tag_numeric(prob.u0, tags),
+        tag_parameters(prob.p, tags),
+        prob.problem_type;
+        prob.kwargs...
+    )
+end
+
+function tag_ode_problem(prob, tags)
+    return SciMLBase.ImmutableODEProblem(
+        prob.f,
+        tag_numeric(prob.u0, tags),
+        prob.tspan,
+        tag_parameters(prob.p, tags),
+        prob.problem_type;
+        prob.kwargs...
+    )
+end
+
+function source_recipe(x::Number, tags)
+    index = findfirst(Base.Fix2(isequal, x), tags)
+    index === nothing && error(
+        "ModelingToolkit initialization maps must copy numeric values from the ODE or initialization problem."
+    )
+    return InitializationSourceIndex(index)
+end
+function source_recipe(x::AbstractArray, tags)
+    values = map(Base.Fix2(source_recipe, tags), x)
+    return SArray{Tuple{size(x)...}}(values)
+end
+source_recipe(x::Tuple, tags) = map(Base.Fix2(source_recipe, tags), x)
+source_recipe(x::NamedTuple, tags) = map(Base.Fix2(source_recipe, tags), x)
+function source_recipe(x, tags)
+    values = ntuple(i -> source_recipe(getfield(x, i), tags), fieldcount(typeof(x)))
+    return InitializationStructureRecipe{typeof(x)}(values)
+end
+
+function make_state_map(initprob, map)
+    map === nothing && return nothing
+    # Evaluate the host-only MTK map on unique numeric tags, then retain only the
+    # resulting device-compatible gather indices.
+    tags = Float64[]
+    tagged_initprob = tag_initialization_problem(initprob, tags)
+    return InitializationStateMap(source_recipe(map(tagged_initprob), tags))
+end
+
+function make_parameter_map(prob, initprob, map)
+    map === nothing && return nothing
+    # Parameter maps may select from both the ODE problem and nonlinear solution.
+    tags = Float64[]
+    tagged_prob = tag_ode_problem(prob, tags)
+    tagged_initprob = tag_initialization_problem(initprob, tags)
+    p = map(tagged_prob, tagged_initprob)
+    p isa MTKParameters || error(
+        "ModelingToolkit initialization parameter maps must return `MTKParameters`."
+    )
+    recipe = InitializationParameterRecipe(
+        source_recipe(p.tunable, tags),
+        source_recipe(p.initials, tags),
+        source_recipe(p.discrete, tags),
+        source_recipe(p.constant, tags)
+    )
+    return InitializationParameterMap(recipe)
+end
+
+function DiffEqGPU.make_initialization_maps_compatible(
+        prob, initprob, umap, pmap, ::MTKParameters
+    )
+    return make_state_map(initprob, umap), make_parameter_map(prob, initprob, pmap)
 end
 
 end

--- a/ext/ModelingToolkitBaseExt.jl
+++ b/ext/ModelingToolkitBaseExt.jl
@@ -110,7 +110,7 @@ function (map::InitializationParameterMap)(prob, sol)
 end
 
 function next_tag!(tags)
-    tag = -1.234567890123456e200 * (length(tags) + 1)
+    tag = Symbol("##DiffEqGPUInitializationTag#", length(tags) + 1)
     push!(tags, tag)
     return tag
 end
@@ -169,7 +169,7 @@ function tag_ode_problem(prob, tags)
     )
 end
 
-function source_recipe(x::Number, tags)
+function source_recipe(x::Union{Number, Symbol}, tags)
     index = findfirst(Base.Fix2(isequal, x), tags)
     index === nothing && error(
         "ModelingToolkit initialization maps must copy numeric values from the ODE or initialization problem."
@@ -189,9 +189,9 @@ end
 
 function make_state_map(initprob, map)
     map === nothing && return nothing
-    # Evaluate the host-only MTK map on unique numeric tags, then retain only the
+    # Evaluate the host-only MTK map on unique symbolic tags, then retain only the
     # resulting device-compatible gather indices.
-    tags = Float64[]
+    tags = Symbol[]
     tagged_initprob = tag_initialization_problem(initprob, tags)
     return InitializationStateMap(source_recipe(map(tagged_initprob), tags))
 end
@@ -199,7 +199,7 @@ end
 function make_parameter_map(prob, initprob, map)
     map === nothing && return nothing
     # Parameter maps may select from both the ODE problem and nonlinear solution.
-    tags = Float64[]
+    tags = Symbol[]
     tagged_prob = tag_ode_problem(prob, tags)
     tagged_initprob = tag_initialization_problem(initprob, tags)
     p = map(tagged_prob, tagged_initprob)

--- a/ext/ModelingToolkitBaseExt.jl
+++ b/ext/ModelingToolkitBaseExt.jl
@@ -109,108 +109,116 @@ function (map::InitializationParameterMap)(prob, sol)
     )
 end
 
-function next_tag!(tags)
-    tag = Symbol("##DiffEqGPUInitializationTag#", length(tags) + 1)
-    push!(tags, tag)
-    return tag
+function next_source_index!(counter)
+    counter[] += 1
+    return counter[]
 end
 
-tag_numeric(x::Number, tags) = next_tag!(tags)
-tag_numeric(x::AbstractArray, tags) = map(Base.Fix2(tag_numeric, tags), x)
-tag_numeric(x::Tuple, tags) = map(Base.Fix2(tag_numeric, tags), x)
-tag_numeric(x::NamedTuple, tags) = map(Base.Fix2(tag_numeric, tags), x)
-function tag_numeric(x, tags)
-    values = ntuple(i -> tag_numeric(getfield(x, i), tags), fieldcount(typeof(x)))
+index_numeric(::Number, counter) = next_source_index!(counter)
+index_numeric(x::AbstractArray, counter) = map(Base.Fix2(index_numeric, counter), x)
+index_numeric(x::Tuple, counter) = map(Base.Fix2(index_numeric, counter), x)
+index_numeric(x::NamedTuple, counter) = map(Base.Fix2(index_numeric, counter), x)
+function index_numeric(x, counter)
+    values = ntuple(i -> index_numeric(getfield(x, i), counter), fieldcount(typeof(x)))
     return typeof(x)(values...)
 end
 
-function tag_parameters(p::MTKParameters, tags)
+function index_parameters(p::MTKParameters, counter)
     return MTKParameters(
-        tag_numeric(p.tunable, tags),
-        tag_numeric(p.initials, tags),
-        tag_numeric(p.discrete, tags),
-        tag_numeric(p.constant, tags),
+        index_numeric(p.tunable, counter),
+        index_numeric(p.initials, counter),
+        index_numeric(p.discrete, counter),
+        index_numeric(p.constant, counter),
         p.nonnumeric,
         p.caches
     )
 end
 
-function tag_initialization_problem(prob::SciMLBase.NonlinearLeastSquaresProblem, tags)
+function index_initialization_problem(prob::SciMLBase.NonlinearLeastSquaresProblem, counter)
     return SciMLBase.NonlinearLeastSquaresProblem{SciMLBase.isinplace(prob)}(
         prob.f,
-        tag_numeric(prob.u0, tags),
-        tag_parameters(prob.p, tags);
+        index_numeric(prob.u0, counter),
+        index_parameters(prob.p, counter);
         lb = prob.lb,
         ub = prob.ub,
         prob.kwargs...
     )
 end
 
-function tag_initialization_problem(
-        prob::Union{SciMLBase.NonlinearProblem, SciMLBase.ImmutableNonlinearProblem}, tags
+function index_initialization_problem(
+        prob::Union{SciMLBase.NonlinearProblem, SciMLBase.ImmutableNonlinearProblem}, counter
     )
     return SciMLBase.ImmutableNonlinearProblem{SciMLBase.isinplace(prob)}(
         prob.f,
-        tag_numeric(prob.u0, tags),
-        tag_parameters(prob.p, tags),
+        index_numeric(prob.u0, counter),
+        index_parameters(prob.p, counter),
         prob.problem_type;
         prob.kwargs...
     )
 end
 
-function tag_ode_problem(prob, tags)
+function index_ode_problem(prob, counter)
     return SciMLBase.ImmutableODEProblem(
         prob.f,
-        tag_numeric(prob.u0, tags),
+        index_numeric(prob.u0, counter),
         prob.tspan,
-        tag_parameters(prob.p, tags),
+        index_parameters(prob.p, counter),
         prob.problem_type;
         prob.kwargs...
     )
 end
 
-function source_recipe(x::Union{Number, Symbol}, tags)
-    index = findfirst(Base.Fix2(isequal, x), tags)
-    index === nothing && error(
-        "ModelingToolkit initialization maps must copy numeric values from the ODE or initialization problem."
-    )
-    return InitializationSourceIndex(index)
+function source_recipe(index::Number, source_count)
+    source_index = try
+        Int(index)
+    catch
+        nothing
+    end
+    if source_index === nothing || !isequal(index, source_index) ||
+            !(1 <= source_index <= source_count)
+        error(
+            "ModelingToolkit initialization maps must copy numeric values from the ODE or initialization problem."
+        )
+    end
+    return InitializationSourceIndex(source_index)
 end
-function source_recipe(x::AbstractArray, tags)
-    values = map(Base.Fix2(source_recipe, tags), x)
+function source_recipe(x::AbstractArray, source_count)
+    values = map(Base.Fix2(source_recipe, source_count), x)
     return SArray{Tuple{size(x)...}}(values)
 end
-source_recipe(x::Tuple, tags) = map(Base.Fix2(source_recipe, tags), x)
-source_recipe(x::NamedTuple, tags) = map(Base.Fix2(source_recipe, tags), x)
-function source_recipe(x, tags)
-    values = ntuple(i -> source_recipe(getfield(x, i), tags), fieldcount(typeof(x)))
+source_recipe(x::Tuple, source_count) = map(Base.Fix2(source_recipe, source_count), x)
+source_recipe(x::NamedTuple, source_count) = map(Base.Fix2(source_recipe, source_count), x)
+function source_recipe(x, source_count)
+    values = ntuple(
+        i -> source_recipe(getfield(x, i), source_count), fieldcount(typeof(x))
+    )
     return InitializationStructureRecipe{typeof(x)}(values)
 end
 
 function make_state_map(initprob, map)
     map === nothing && return nothing
-    # Evaluate the host-only MTK map on unique symbolic tags, then retain only the
-    # resulting device-compatible gather indices.
-    tags = Symbol[]
-    tagged_initprob = tag_initialization_problem(initprob, tags)
-    return InitializationStateMap(source_recipe(map(tagged_initprob), tags))
+    # Evaluate the host-only MTK map on sequential source indices, then retain its
+    # device-compatible gather recipe.
+    counter = Ref(0)
+    indexed_initprob = index_initialization_problem(initprob, counter)
+    return InitializationStateMap(source_recipe(map(indexed_initprob), counter[]))
 end
 
 function make_parameter_map(prob, initprob, map)
     map === nothing && return nothing
     # Parameter maps may select from both the ODE problem and nonlinear solution.
-    tags = Symbol[]
-    tagged_prob = tag_ode_problem(prob, tags)
-    tagged_initprob = tag_initialization_problem(initprob, tags)
-    p = map(tagged_prob, tagged_initprob)
+    counter = Ref(0)
+    indexed_prob = index_ode_problem(prob, counter)
+    indexed_initprob = index_initialization_problem(initprob, counter)
+    p = map(indexed_prob, indexed_initprob)
     p isa MTKParameters || error(
         "ModelingToolkit initialization parameter maps must return `MTKParameters`."
     )
     recipe = InitializationParameterRecipe(
-        source_recipe(p.tunable, tags),
-        source_recipe(p.initials, tags),
-        source_recipe(p.discrete, tags),
-        source_recipe(p.constant, tags)
+        source_recipe(p.tunable, counter[]),
+        source_recipe(p.initials, counter[]),
+        source_recipe(p.discrete, counter[]),
+        source_recipe(p.constant, counter[])
     )
     return InitializationParameterMap(recipe)
 end

--- a/src/ensemblegpukernel/kernels.jl
+++ b/src/ensemblegpukernel/kernels.jl
@@ -41,7 +41,7 @@
             end
         else
             @inbounds ts[integ.step_idx] = prob.tspan[1]
-            @inbounds us[integ.step_idx] = prob.u0
+            @inbounds us[integ.step_idx] = u0
         end
 
         integ.step_idx += 1

--- a/src/ensemblegpukernel/nlsolve/initialization.jl
+++ b/src/ensemblegpukernel/nlsolve/initialization.jl
@@ -32,7 +32,7 @@
     sol = SciMLBase.solve(initprob, alg; abstol, reltol)
 
     # Extract results — initialization must succeed
-    if !SciMLBase.successful_retcode(sol)
+    if !gpu_initialization_success(initprob, sol, abstol)
         return u0, p, false
     end
 

--- a/src/ensemblegpukernel/nlsolve/initialization.jl
+++ b/src/ensemblegpukernel/nlsolve/initialization.jl
@@ -32,7 +32,7 @@
     sol = SciMLBase.solve(initprob, alg; abstol, reltol)
 
     # Extract results — initialization must succeed
-    if !gpu_initialization_success(initprob, sol, abstol)
+    if !SciMLBase.successful_retcode(sol)
         return u0, p, false
     end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,25 +6,20 @@ end
 diffeqgpunorm(u::ForwardDiff.Dual, t) = abs(ForwardDiff.value(u))
 
 """
-    make_prob_compatible(prob; nlsolve_alg = SimpleTrustRegion(), abstol = 1e-6,
-        reltol = 1e-6)
+    make_prob_compatible(prob)
 
 Prepare a problem for the lower-level `EnsembleGPUKernel` interface.
 
-For an `ODEProblem`, this solves any initialization problem on the host, removes the
-initialization metadata, converts the problem to an immutable representation, and adapts
-parameter and mass-matrix storage when needed. Other problem-like values are returned
-unchanged. The resulting problem must still satisfy the selected backend's
+For an `ODEProblem`, this updates any initialization problem on the host, converts the
+initialization problem and its maps to immutable static representations for device-side
+solving, and adapts parameter and mass-matrix storage. Other problem-like values are
+returned unchanged. The resulting problem must still satisfy the selected backend's
 GPU-compatibility requirements.
 
 # Arguments
 
   - `prob`: an `ODEProblem` or another problem value accepted by the lower-level ensemble
     interface.
-  - `nlsolve_alg`: nonlinear solver used for problem initialization.
-  - `abstol`: absolute tolerance used for problem initialization.
-  - `reltol`: relative tolerance used for problem initialization.
-
 # Returns
 
 An immutable, backend-compatible representation for ODE problems, or `prob` unchanged for
@@ -42,36 +37,143 @@ gpu_prob = DiffEqGPU.make_prob_compatible(prob)
 make_prob_compatible(prob; kwargs...) = prob
 make_parameter_compatible(p) = p
 
-function make_prob_compatible(
-        prob::T; nlsolve_alg = SimpleTrustRegion(), abstol = 1.0e-6,
-        reltol = 1.0e-6
-    ) where {T <: ODEProblem}
+function make_prob_compatible(prob::T) where {T <: ODEProblem}
     if SciMLBase.has_initialization_data(prob.f)
-        return _initialized_problem_compatible(prob, nlsolve_alg, abstol, reltol)
+        return _initialized_problem_compatible(prob)
     end
 
     prob = remake(prob; p = make_parameter_compatible(prob.p))
     return convert(ImmutableODEProblem, _maybe_convert_mass_matrix(prob))
 end
 
-function _initialized_problem_compatible(prob, nlsolve_alg, abstol, reltol)
-    u0, p, success = gpu_initialization_solve(prob, nlsolve_alg, abstol, reltol)
-    success || error("Initialization failed while preparing an ODEProblem for EnsembleGPUKernel.")
-
+function _initialized_problem_compatible(prob)
     oldf = prob.f
-    mass_matrix = _compatible_mass_matrix(oldf.mass_matrix, length(u0))
+    initdata = oldf.initialization_data
+    initprob = initdata.initializeprob
+    if initdata.update_initializeprob! !== nothing
+        initprob = if initdata.is_update_oop === Val(true)
+            initdata.update_initializeprob!(initprob, prob)
+        else
+            initdata.update_initializeprob!(initprob, prob)
+            initprob
+        end
+    end
+    initprobmap, initprobpmap = make_initialization_maps_compatible(
+        prob, initprob, initdata.initializeprobmap, initdata.initializeprobpmap, prob.p
+    )
+    compatible_initdata = SciMLBase.OverrideInitData(
+        make_nonlinear_problem_compatible(initprob), nothing, initprobmap, initprobpmap,
+        nothing, Val(false)
+    )
+
+    mass_matrix = _compatible_mass_matrix(oldf.mass_matrix, length(prob.u0))
     newf = SciMLBase.ODEFunction{
         SciMLBase.isinplace(oldf), SciMLBase.specialization(oldf),
     }(
         oldf.f;
         jac = oldf.jac,
         mass_matrix,
-        initialization_data = nothing
+        initialization_data = compatible_initdata
     )
-    static_u0 = StaticArrays.SVector{length(u0)}(u0)
-    static_p = make_parameter_compatible(p)
+    static_u0 = make_static_storage(prob.u0)
+    static_p = make_parameter_compatible(prob.p)
     return ImmutableODEProblem(
         newf, static_u0, prob.tspan, static_p, prob.problem_type; prob.kwargs...
+    )
+end
+
+make_initialization_maps_compatible(prob, initprob, umap, pmap, p) = (umap, pmap)
+
+make_static_storage(x::StaticArrays.StaticArray) =
+    StaticArrays.SArray{Tuple{size(x)...}}(map(make_static_storage, x))
+make_static_storage(x::Array) =
+    StaticArrays.SArray{Tuple{size(x)...}}(map(make_static_storage, x))
+make_static_storage(x::Tuple) = map(make_static_storage, x)
+make_static_storage(x::NamedTuple) = map(make_static_storage, x)
+make_static_storage(x) = x
+
+function make_nonlinear_function_compatible(oldf)
+    return SciMLBase.NonlinearFunction{
+        false, SciMLBase.FullSpecialize,
+    }(
+        oldf.f;
+        resid_prototype = make_static_storage(oldf.resid_prototype)
+    )
+end
+
+struct GPUInitializationFunction{F, U, R, P}
+    f::F
+    reference_u0::U
+    residual_indices::R
+    pinned_indices::P
+end
+
+function (f::GPUInitializationFunction)(u, p)
+    residual = f.f(u, p)
+    selected = map(i -> residual[i], f.residual_indices)
+    pinned = map(i -> u[i] - f.reference_u0[i], f.pinned_indices)
+    return StaticArrays.SVector((selected..., pinned...))
+end
+
+@inline function gpu_initialization_success(initprob, sol, abstol)
+    SciMLBase.successful_retcode(sol) || return false
+    initprob.f.f isa GPUInitializationFunction || return true
+    residual = initprob.f.f.f(sol.u, initprob.p)
+    return LinearAlgebra.norm(residual) <= abstol
+end
+
+function independent_initialization_indices(f, u0, p)
+    # StaticArrays' rectangular least-squares factorization allocates. Select a square
+    # independent constraint set and pin only the free directions to their supplied
+    # guesses; `gpu_initialization_success` still checks every original residual.
+    jac = Matrix(ForwardDiff.jacobian(Base.Fix2(f, p), u0))
+    jac_rank = LinearAlgebra.rank(jac)
+    jac_rank == 0 && return (), Tuple(eachindex(u0))
+
+    row_factorization = LinearAlgebra.qr(
+        transpose(jac), LinearAlgebra.ColumnNorm()
+    )
+    residual_indices = Tuple(row_factorization.p[1:jac_rank])
+    independent_rows = @view jac[collect(residual_indices), :]
+    column_factorization = LinearAlgebra.qr(
+        independent_rows, LinearAlgebra.ColumnNorm()
+    )
+    independent_columns = column_factorization.p[1:jac_rank]
+    pinned_indices = Tuple(setdiff(eachindex(u0), independent_columns))
+    return residual_indices, pinned_indices
+end
+
+function make_nonlinear_problem_compatible(prob::SciMLBase.NonlinearLeastSquaresProblem)
+    (prob.lb === nothing && prob.ub === nothing) || error(
+        "Bounded nonlinear initialization problems are not supported by EnsembleGPUKernel."
+    )
+    static_u0 = make_static_storage(prob.u0)
+    static_p = make_parameter_compatible(prob.p)
+    compatible_f = make_nonlinear_function_compatible(prob.f)
+    residual_indices, pinned_indices = independent_initialization_indices(
+        compatible_f, static_u0, static_p
+    )
+    square_f = GPUInitializationFunction(
+        compatible_f, static_u0, residual_indices, pinned_indices
+    )
+    nonlinear_f = SciMLBase.NonlinearFunction{false, SciMLBase.FullSpecialize}(
+        square_f; resid_prototype = zero(static_u0)
+    )
+    return SciMLBase.ImmutableNonlinearProblem{false}(
+        nonlinear_f, static_u0, static_p;
+        prob.kwargs...
+    )
+end
+
+function make_nonlinear_problem_compatible(
+        prob::Union{SciMLBase.NonlinearProblem, SciMLBase.ImmutableNonlinearProblem}
+    )
+    return SciMLBase.ImmutableNonlinearProblem{false}(
+        make_nonlinear_function_compatible(prob.f),
+        make_static_storage(prob.u0),
+        make_parameter_compatible(prob.p),
+        prob.problem_type;
+        prob.kwargs...
     )
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -113,9 +113,11 @@ function make_nonlinear_problem_compatible(prob::SciMLBase.NonlinearLeastSquares
     end
     if nresiduals != nunknowns
         status = nresiduals < nunknowns ? "underdetermined" : "overdetermined"
-        throw(ArgumentError(
-            "$status nonlinear initialization problems are not supported by EnsembleGPUKernel: $nresiduals residuals for $nunknowns unknowns."
-        ))
+        throw(
+            ArgumentError(
+                "$status nonlinear initialization problems are not supported by EnsembleGPUKernel: $nresiduals residuals for $nunknowns unknowns."
+            )
+        )
     end
 
     static_u0 = make_static_storage(prob.u0)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -101,66 +101,29 @@ function make_nonlinear_function_compatible(oldf)
     )
 end
 
-struct GPUInitializationFunction{F, U, R, P}
-    f::F
-    reference_u0::U
-    residual_indices::R
-    pinned_indices::P
-end
-
-function (f::GPUInitializationFunction)(u, p)
-    residual = f.f(u, p)
-    selected = map(i -> residual[i], f.residual_indices)
-    pinned = map(i -> u[i] - f.reference_u0[i], f.pinned_indices)
-    return StaticArrays.SVector((selected..., pinned...))
-end
-
-@inline function gpu_initialization_success(initprob, sol, abstol)
-    SciMLBase.successful_retcode(sol) || return false
-    initprob.f.f isa GPUInitializationFunction || return true
-    residual = initprob.f.f.f(sol.u, initprob.p)
-    return LinearAlgebra.norm(residual) <= abstol
-end
-
-function independent_initialization_indices(f, u0, p)
-    # StaticArrays' rectangular least-squares factorization allocates. Select a square
-    # independent constraint set and pin only the free directions to their supplied
-    # guesses; `gpu_initialization_success` still checks every original residual.
-    jac = Matrix(ForwardDiff.jacobian(Base.Fix2(f, p), u0))
-    jac_rank = LinearAlgebra.rank(jac)
-    jac_rank == 0 && return (), Tuple(eachindex(u0))
-
-    row_factorization = LinearAlgebra.qr(
-        transpose(jac), LinearAlgebra.ColumnNorm()
-    )
-    residual_indices = Tuple(row_factorization.p[1:jac_rank])
-    independent_rows = @view jac[collect(residual_indices), :]
-    column_factorization = LinearAlgebra.qr(
-        independent_rows, LinearAlgebra.ColumnNorm()
-    )
-    independent_columns = column_factorization.p[1:jac_rank]
-    pinned_indices = Tuple(setdiff(eachindex(u0), independent_columns))
-    return residual_indices, pinned_indices
-end
-
 function make_nonlinear_problem_compatible(prob::SciMLBase.NonlinearLeastSquaresProblem)
     (prob.lb === nothing && prob.ub === nothing) || error(
         "Bounded nonlinear initialization problems are not supported by EnsembleGPUKernel."
     )
+    nunknowns = length(prob.u0)
+    nresiduals = if prob.f.resid_prototype === nothing
+        nunknowns
+    else
+        length(prob.f.resid_prototype)
+    end
+    if nresiduals != nunknowns
+        status = nresiduals < nunknowns ? "underdetermined" : "overdetermined"
+        throw(ArgumentError(
+            "$status nonlinear initialization problems are not supported by EnsembleGPUKernel: $nresiduals residuals for $nunknowns unknowns."
+        ))
+    end
+
     static_u0 = make_static_storage(prob.u0)
     static_p = make_parameter_compatible(prob.p)
-    compatible_f = make_nonlinear_function_compatible(prob.f)
-    residual_indices, pinned_indices = independent_initialization_indices(
-        compatible_f, static_u0, static_p
-    )
-    square_f = GPUInitializationFunction(
-        compatible_f, static_u0, residual_indices, pinned_indices
-    )
-    nonlinear_f = SciMLBase.NonlinearFunction{false, SciMLBase.FullSpecialize}(
-        square_f; resid_prototype = zero(static_u0)
-    )
-    return SciMLBase.ImmutableNonlinearProblem{false}(
-        nonlinear_f, static_u0, static_p;
+    return SciMLBase.NonlinearLeastSquaresProblem{false}(
+        make_nonlinear_function_compatible(prob.f), static_u0, static_p;
+        lb = prob.lb,
+        ub = prob.ub,
         prob.kwargs...
     )
 end

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
@@ -133,7 +133,28 @@ end
 end
 
 # ============================================================================
-# Test 3: ModelingToolkit cartesian pendulum DAE with initialization
+# Test 3: Non-square initialization errors
+# ============================================================================
+
+@testset "Overdetermined initialization error" begin
+    overdetermined_f = SciMLBase.NonlinearFunction{false}(
+        (u, p) -> SA[u[1], u[2], u[1] + u[2]];
+        resid_prototype = SA[0.0, 0.0, 0.0]
+    )
+    overdetermined_prob = SciMLBase.NonlinearLeastSquaresProblem{false}(
+        overdetermined_f, SA[1.0, 1.0], nothing
+    )
+    overdetermined_error = try
+        DiffEqGPU.make_nonlinear_problem_compatible(overdetermined_prob)
+    catch err
+        err
+    end
+    @test overdetermined_error isa ArgumentError
+    @test occursin("overdetermined", sprint(showerror, overdetermined_error))
+end
+
+# ============================================================================
+# Test 4: ModelingToolkit cartesian pendulum DAE with initialization
 # ============================================================================
 
 @testset "MTK Pendulum DAE with initialization" begin
@@ -148,9 +169,22 @@ end
 
     @mtkcompile pendulum = ODESystem(eqs, t, [px, py, pλ], [g, L])
 
-    mtk_prob = ODEProblem(
+    underdetermined_prob = ODEProblem(
         pendulum, [py => 0.99], (0.0, 1.0),
         guesses = [pλ => 0.0, px => 0.1, D(px) => 0.0, D(py) => 0.0]
+    )
+    underdetermined_error = try
+        DiffEqGPU.make_prob_compatible(underdetermined_prob)
+    catch err
+        err
+    end
+    @test underdetermined_error isa ArgumentError
+    @test occursin("underdetermined", sprint(showerror, underdetermined_error))
+
+    mtk_prob = ODEProblem(
+        pendulum, [py => 0.99, D(px) => 0.0], (0.0, 1.0),
+        guesses = [pλ => 0.0, px => 0.1, D(py) => 0.0],
+        use_scc = false
     )
 
     @test SciMLBase.has_initialization_data(mtk_prob.f)

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
@@ -158,7 +158,11 @@ end
 
     compatible_prob = DiffEqGPU.make_prob_compatible(mtk_prob)
     @test isbitstype(typeof(compatible_prob))
-    @test !SciMLBase.has_initialization_data(compatible_prob.f)
+    @test SciMLBase.has_initialization_data(compatible_prob.f)
+    @test isbitstype(typeof(compatible_prob.f.initialization_data.initializeprob))
+    @test compatible_prob.f.initialization_data.initializeprob isa
+        SciMLBase.ImmutableNonlinearProblem
+    @test compatible_prob.u0 == SVector{length(mtk_prob.u0)}(mtk_prob.u0)
 
     ref_sol = solve(mtk_prob, Rodas5P())
     @test SciMLBase.successful_retcode(ref_sol)
@@ -172,5 +176,6 @@ end
     )
     @test length(sol_mtk.u) == 2
     @test !any(isnan, sol_mtk.u[1].u[end])
+    @test norm(sol_mtk.u[1].u[1] - ref_sol.u[1]) < 1.0e-6
     @test norm(sol_mtk.u[1].u[end] - ref_sol.u[end]) < 1.0
 end


### PR DESCRIPTION
## Summary
- preserve and staticize MTK initialization problems for EnsembleGPUKernel
- replace host-only MTK reconstruction closures with isbits gather recipes
- run SimpleTrustRegion initialization per trajectory in the kernel
- reject underdetermined and overdetermined initialization systems with explicit errors

## Validation
- JLArrays MTK DAE tests pass, including initialized initial-state comparison and non-square error regressions
- CUDA device compilation reaches cubin generation; this local Pascal setup fails only while loading it with CUDA error 801
- QA passes 21/21
- JET passes 75/75
- public-interface tests pass
- Runic and git diff check pass

Follow-up to #505.