### PR TITLE
Run MTK SCC initialization sequentially on GPU kernels

### DIFF
--- a/docs/src/tutorials/modelingtoolkit.md
+++ b/docs/src/tutorials/modelingtoolkit.md
@@ -118,7 +118,12 @@ ModelingToolkit can generate a nonlinear initialization problem for a mass-matri
 copy per trajectory inside the GPU kernel. Square systems use `SimpleTrustRegion`, while
 rectangular nonlinear least-squares systems use `SimpleGaussNewton`, both from
 SimpleNonlinearSolve.jl. The resulting consistent state and parameters are used to start
-the ODE solve.
+the ODE solve. ModelingToolkit's default `SCCNonlinearProblem` representation is lowered
+to an immutable nonlinear problem plus statically typed SCC block metadata. The blocks
+are solved sequentially in the kernel: nonlinear blocks use `SimpleTrustRegion`, and
+linear blocks use DiffEqGPU's device-compatible static square solve (closed-form for
+blocks of size three or smaller and pivoted LU otherwise). The mutable SCC caches and
+linear-problem update wrappers are not placed in the kernel.
 
 For example, the Cartesian pendulum can be initialized and solved as follows:
 
@@ -142,7 +147,6 @@ prob = ODEProblem(
     [py => 0.99, D(px) => 0.0],
     (0.0, 1.0);
     guesses = [pλ => 0.0, px => 0.1, D(py) => 0.0],
-    use_scc = false,
 )
 
 ensemble_prob = EnsembleProblem(prob; safetycopy = false)
@@ -171,6 +175,8 @@ The current initialization path has the following restrictions:
     traces those operations on the host and stores only static gather recipes in the
     kernel. Fallback getters that evaluate derived symbolic expressions are not yet
     lowered.
+  - Ordinary nonlinear and linear SCC initialization blocks are supported. SCC
+    initialization containing Modelica homotopy blocks is not supported.
 
 Structured `MTKParameters` storage is converted recursively to static storage, so this
 path does not require `split = false`.

--- a/ext/ModelingToolkitBaseExt.jl
+++ b/ext/ModelingToolkitBaseExt.jl
@@ -1,6 +1,6 @@
 module ModelingToolkitBaseExt
 
-using ModelingToolkitBase: MTKParameters, System
+using ModelingToolkitBase: MTKParameters, System, unknowns
 using StaticArraysCore: SArray, StaticArray, SVector
 import DiffEqGPU
 import SciMLBase
@@ -41,20 +41,29 @@ function DiffEqGPU.lower_initialization_problem(prob::SciMLBase.SCCNonlinearProb
         )
     )
 
-    u0 = SciMLBase.state_values(prob)
+    block_states = map(prob.probs) do block_prob
+        block_u0 = SciMLBase.state_values(block_prob)
+        block_u0 !== nothing && return block_u0
+        # A linear block is solved by one exact Newton step, which lands on the solution
+        # from any seed, so a zero seed stands in for the missing state.
+        block_prob isa SciMLBase.LinearProblem || throw(
+            ArgumentError(
+                "Every nonlinear SCC initialization block must have an initial state for EnsembleGPUKernel."
+            )
+        )
+        zero(block_prob.b)
+    end
+    u0 = reduce(vcat, block_states)
+    length(u0) == length(unknowns(sys)) || throw(
+        ArgumentError("SCC initialization block sizes do not match the full state size.")
+    )
     f = SciMLBase.NonlinearFunction{false, SciMLBase.FullSpecialize}(
         sys; u0, p = prob.p, check_compatibility = false
     )
     nonlinear_prob = SciMLBase.NonlinearProblem{false}(f, u0, prob.p)
 
     offset = 0
-    blocks = map(prob.probs) do block_prob
-        block_u0 = SciMLBase.state_values(block_prob)
-        block_u0 === nothing && throw(
-            ArgumentError(
-                "Every SCC initialization block must have an initial state for EnsembleGPUKernel."
-            )
-        )
+    blocks = map(prob.probs, block_states) do block_prob, block_u0
         n = length(block_u0)
         block = DiffEqGPU.ImmutableSCCBlock{
             offset + 1, n, block_prob isa SciMLBase.LinearProblem,
@@ -62,9 +71,6 @@ function DiffEqGPU.lower_initialization_problem(prob::SciMLBase.SCCNonlinearProb
         offset += n
         block
     end
-    offset == length(u0) || throw(
-        ArgumentError("SCC initialization block sizes do not match the full state size.")
-    )
     return DiffEqGPU.ImmutableSCCNonlinearProblem(nonlinear_prob, Tuple(blocks))
 end
 

--- a/ext/ModelingToolkitBaseExt.jl
+++ b/ext/ModelingToolkitBaseExt.jl
@@ -1,6 +1,6 @@
 module ModelingToolkitBaseExt
 
-using ModelingToolkitBase: MTKParameters
+using ModelingToolkitBase: MTKParameters, System
 using StaticArraysCore: SArray, StaticArray, SVector
 import DiffEqGPU
 import SciMLBase
@@ -26,6 +26,46 @@ function DiffEqGPU.make_parameter_compatible(p::MTKParameters)
         static_parameter_storage(p.nonnumeric),
         static_parameter_storage(p.caches)
     )
+end
+
+function DiffEqGPU.lower_initialization_problem(prob::SciMLBase.SCCNonlinearProblem)
+    sys = prob.f.sys
+    sys isa System || throw(
+        ArgumentError(
+            "Only ModelingToolkit-generated SCC nonlinear initialization problems can be lowered for EnsembleGPUKernel."
+        )
+    )
+    any(p -> nameof(typeof(p)) === :HomotopyProblem, prob.probs) && throw(
+        ArgumentError(
+            "SCC nonlinear initialization problems containing homotopy blocks are not supported by EnsembleGPUKernel."
+        )
+    )
+
+    u0 = SciMLBase.state_values(prob)
+    f = SciMLBase.NonlinearFunction{false, SciMLBase.FullSpecialize}(
+        sys; u0, p = prob.p, check_compatibility = false
+    )
+    nonlinear_prob = SciMLBase.NonlinearProblem{false}(f, u0, prob.p)
+
+    offset = 0
+    blocks = map(prob.probs) do block_prob
+        block_u0 = SciMLBase.state_values(block_prob)
+        block_u0 === nothing && throw(
+            ArgumentError(
+                "Every SCC initialization block must have an initial state for EnsembleGPUKernel."
+            )
+        )
+        n = length(block_u0)
+        block = DiffEqGPU.ImmutableSCCBlock{
+            offset + 1, n, block_prob isa SciMLBase.LinearProblem,
+        }()
+        offset += n
+        block
+    end
+    offset == length(u0) || throw(
+        ArgumentError("SCC initialization block sizes do not match the full state size.")
+    )
+    return DiffEqGPU.ImmutableSCCNonlinearProblem(nonlinear_prob, Tuple(blocks))
 end
 
 struct InitializationSourceIndex{I} end
@@ -153,6 +193,12 @@ function index_initialization_problem(prob::SciMLBase.NonlinearLeastSquaresProbl
         ub = prob.ub,
         prob.kwargs...
     )
+end
+
+function index_initialization_problem(
+        prob::DiffEqGPU.ImmutableSCCNonlinearProblem, counter
+    )
+    return index_initialization_problem(prob.problem, counter)
 end
 
 function index_initialization_problem(

--- a/src/ensemblegpukernel/nlsolve/initialization.jl
+++ b/src/ensemblegpukernel/nlsolve/initialization.jl
@@ -94,30 +94,38 @@ end
     return SVector{N}(ntuple(i -> full_u[I + i - 1], Val(N)))
 end
 
-@inline function solve_scc_block(
-        prob, full_u, ::ImmutableSCCBlock{I, N, true}, alg, abstol, reltol
-    ) where {I, N}
-    residual = SCCBlockResidual{typeof(prob.f), typeof(prob.p), typeof(full_u), I, N}(
+@inline function scc_block_residual(prob, full_u, ::ImmutableSCCBlock{I, N}) where {I, N}
+    return SCCBlockResidual{typeof(prob.f), typeof(prob.p), typeof(full_u), I, N}(
         prob.f, prob.p, full_u
     )
-    u0 = scc_block_state(full_u, ImmutableSCCBlock{I, N, true}())
+end
+
+@inline replace_scc_block(full_u, block_u, ::ImmutableSCCBlock{I, N}) where {I, N} =
+    replace_scc_block(full_u, block_u, Val(I), Val(N))
+
+# The Jacobian is re-derived here instead of reusing the `A`/`b` of MTK's linear SCC block:
+# those come from a mutable update function of the upstream blocks' solutions, so they
+# would have to be re-evaluated per trajectory on the device anyway. Differentiating the
+# flattened residual yields the same matrix while keeping the update wrappers on the host.
+@inline function solve_scc_block(
+        prob, full_u, block::ImmutableSCCBlock{I, N, true}, alg, abstol, reltol
+    ) where {I, N}
+    residual = scc_block_residual(prob, full_u, block)
+    u0 = scc_block_state(full_u, block)
     r0 = residual(u0)
-    J = ForwardDiff.jacobian(residual, u0)
-    rhs = J * u0 - r0
-    u = linear_solve(J, rhs)
+    # A linear block's residual is affine, so one Newton step is exact. Solving for the step
+    # avoids forming `J * u0`, which cancels against `r0` for states large next to the step.
+    u = u0 - linear_solve(ForwardDiff.jacobian(residual, u0), r0)
     tolerance = abstol + reltol * initialization_residual_norm(r0)
-    success = initialization_residual_norm(residual(u)) <= tolerance
-    return u, success
+    return u, initialization_residual_norm(residual(u)) <= tolerance
 end
 
 @inline function solve_scc_block(
-        prob, full_u, ::ImmutableSCCBlock{I, N, false}, alg, abstol, reltol
+        prob, full_u, block::ImmutableSCCBlock{I, N, false}, alg, abstol, reltol
     ) where {I, N}
-    residual = SCCBlockResidual{typeof(prob.f), typeof(prob.p), typeof(full_u), I, N}(
-        prob.f, prob.p, full_u
+    block_prob = SciMLBase.ImmutableNonlinearProblem{false}(
+        scc_block_residual(prob, full_u, block), scc_block_state(full_u, block)
     )
-    u0 = scc_block_state(full_u, ImmutableSCCBlock{I, N, false}())
-    block_prob = SciMLBase.ImmutableNonlinearProblem{false}(residual, u0)
     sol = SciMLBase.solve(block_prob, alg; abstol, reltol)
     return sol.u, SciMLBase.successful_retcode(sol)
 end
@@ -127,12 +135,9 @@ end
     block = first(blocks)
     block_u, success = solve_scc_block(prob, full_u, block, alg, abstol, reltol)
     success || return full_u, false
-    I, N = scc_block_range(block)
-    updated_u = replace_scc_block(full_u, block_u, I, N)
+    updated_u = replace_scc_block(full_u, block_u, block)
     return solve_scc_blocks(prob, updated_u, Base.tail(blocks), alg, abstol, reltol)
 end
-
-@inline scc_block_range(::ImmutableSCCBlock{I, N}) where {I, N} = (Val(I), Val(N))
 
 @inline function solve_initialization_problem(
         nonlinear_prob, metadata::ImmutableSCCInitialization, alg, abstol, reltol

--- a/src/ensemblegpukernel/nlsolve/initialization.jl
+++ b/src/ensemblegpukernel/nlsolve/initialization.jl
@@ -146,6 +146,11 @@ end
         nonlinear_prob, nonlinear_prob.u0, metadata.blocks, alg, abstol, reltol
     )
     residual = nonlinear_prob.f(u, nonlinear_prob.p)
+    # Block-level success trusts the lowered block layout; the full residual also has to
+    # vanish, so a layout that is not actually block-triangular cannot pass silently.
+    r0 = nonlinear_prob.f(nonlinear_prob.u0, nonlinear_prob.p)
+    tolerance = abstol + reltol * initialization_residual_norm(r0)
+    success = success && initialization_residual_norm(residual) <= tolerance
     retcode = success ? ReturnCode.Success : ReturnCode.Failure
     return SciMLBase.build_solution(nonlinear_prob, alg, u, residual; retcode)
 end

--- a/src/ensemblegpukernel/nlsolve/initialization.jl
+++ b/src/ensemblegpukernel/nlsolve/initialization.jl
@@ -4,6 +4,25 @@ struct BoundedInitializationFunction{F, L, U}
     ub::U
 end
 
+"""
+Device-compatible representation of an SCC-split initialization problem.
+
+`problem` is the out-of-place residual for the complete initialization system. `blocks`
+stores the statically known row/state range of each SCC and whether the block is linear.
+Keeping only immutable, fully specialized data avoids the mutable cache writers used by
+the host `SCCNonlinearProblem` representation.
+"""
+struct ImmutableSCCNonlinearProblem{P, B}
+    problem::P
+    blocks::B
+end
+
+struct ImmutableSCCBlock{I, N, L} end
+
+struct ImmutableSCCInitialization{B}
+    blocks::B
+end
+
 @inline function _from_unbounded_initialization(u, lb, ub)
     if isfinite(lb) && isfinite(ub)
         return lb + (ub - lb) / (one(u) + exp(-u))
@@ -48,6 +67,86 @@ end
 end
 
 @inline initialization_residual_norm(residual) = sqrt(sum(abs2, residual))
+
+struct SCCBlockResidual{F, P, U, I, N}
+    f::F
+    p::P
+    full_u::U
+end
+
+@inline function replace_scc_block(
+        full_u::StaticVector{M}, block_u, ::Val{I}, ::Val{N}
+    ) where {M, I, N}
+    values = ntuple(Val(M)) do j
+        I <= j < I + N ? block_u[j - I + 1] : full_u[j]
+    end
+    return SVector(values)
+end
+
+@inline function (f::SCCBlockResidual{F, P, U, I, N})(block_u) where {F, P, U, I, N}
+    full_u = replace_scc_block(f.full_u, block_u, Val(I), Val(N))
+    residual = f.f(full_u, f.p)
+    return SVector{N}(ntuple(i -> residual[I + i - 1], Val(N)))
+end
+@inline (f::SCCBlockResidual)(block_u, p) = f(block_u)
+
+@inline function scc_block_state(full_u, ::ImmutableSCCBlock{I, N}) where {I, N}
+    return SVector{N}(ntuple(i -> full_u[I + i - 1], Val(N)))
+end
+
+@inline function solve_scc_block(
+        prob, full_u, ::ImmutableSCCBlock{I, N, true}, alg, abstol, reltol
+    ) where {I, N}
+    residual = SCCBlockResidual{typeof(prob.f), typeof(prob.p), typeof(full_u), I, N}(
+        prob.f, prob.p, full_u
+    )
+    u0 = scc_block_state(full_u, ImmutableSCCBlock{I, N, true}())
+    r0 = residual(u0)
+    J = ForwardDiff.jacobian(residual, u0)
+    rhs = J * u0 - r0
+    u = linear_solve(J, rhs)
+    tolerance = abstol + reltol * initialization_residual_norm(r0)
+    success = initialization_residual_norm(residual(u)) <= tolerance
+    return u, success
+end
+
+@inline function solve_scc_block(
+        prob, full_u, ::ImmutableSCCBlock{I, N, false}, alg, abstol, reltol
+    ) where {I, N}
+    residual = SCCBlockResidual{typeof(prob.f), typeof(prob.p), typeof(full_u), I, N}(
+        prob.f, prob.p, full_u
+    )
+    u0 = scc_block_state(full_u, ImmutableSCCBlock{I, N, false}())
+    block_prob = SciMLBase.ImmutableNonlinearProblem{false}(residual, u0)
+    sol = SciMLBase.solve(block_prob, alg; abstol, reltol)
+    return sol.u, SciMLBase.successful_retcode(sol)
+end
+
+@inline solve_scc_blocks(prob, full_u, ::Tuple{}, alg, abstol, reltol) = (full_u, true)
+@inline function solve_scc_blocks(prob, full_u, blocks::Tuple, alg, abstol, reltol)
+    block = first(blocks)
+    block_u, success = solve_scc_block(prob, full_u, block, alg, abstol, reltol)
+    success || return full_u, false
+    I, N = scc_block_range(block)
+    updated_u = replace_scc_block(full_u, block_u, I, N)
+    return solve_scc_blocks(prob, updated_u, Base.tail(blocks), alg, abstol, reltol)
+end
+
+@inline scc_block_range(::ImmutableSCCBlock{I, N}) where {I, N} = (Val(I), Val(N))
+
+@inline function solve_initialization_problem(
+        nonlinear_prob, metadata::ImmutableSCCInitialization, alg, abstol, reltol
+    )
+    u, success = solve_scc_blocks(
+        nonlinear_prob, nonlinear_prob.u0, metadata.blocks, alg, abstol, reltol
+    )
+    residual = nonlinear_prob.f(u, nonlinear_prob.p)
+    retcode = success ? ReturnCode.Success : ReturnCode.Failure
+    return SciMLBase.build_solution(nonlinear_prob, alg, u, residual; retcode)
+end
+
+@inline solve_initialization_problem(prob, metadata, alg, abstol, reltol) =
+    solve_initialization_problem(prob, alg, abstol, reltol)
 
 @inline function gpu_rectangular_gauss_newton_solve(prob, abstol; maxiters = 1000)
     u = prob.u0
@@ -123,7 +222,9 @@ end
         initprob
     else
         alg = initialization_algorithm(initprob, nlsolve_alg)
-        nlsol = solve_initialization_problem(initprob, alg, abstol, reltol)
+        nlsol = solve_initialization_problem(
+            initprob, initdata.metadata, alg, abstol, reltol
+        )
         SciMLBase.successful_retcode(nlsol) || return u0, p, false
         restore_bounded_initialization(nlsol, initprob)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,12 +58,21 @@ function _initialized_problem_compatible(prob)
             initprob
         end
     end
+    initprob = lower_initialization_problem(initprob)
     initprobmap, initprobpmap = make_initialization_maps_compatible(
         prob, initprob, initdata.initializeprobmap, initdata.initializeprobpmap, prob.p
     )
+    compatible_initprob = make_nonlinear_problem_compatible(initprob)
+    compatible_initprob, metadata = if compatible_initprob isa ImmutableSCCNonlinearProblem
+        compatible_initprob.problem, ImmutableSCCInitialization(compatible_initprob.blocks)
+    elseif initdata.metadata isa ImmutableSCCInitialization
+        compatible_initprob, initdata.metadata
+    else
+        compatible_initprob, nothing
+    end
     compatible_initdata = SciMLBase.OverrideInitData(
-        make_nonlinear_problem_compatible(initprob), nothing, initprobmap, initprobpmap,
-        nothing, Val(false)
+        compatible_initprob, nothing, initprobmap, initprobpmap,
+        metadata, Val(false)
     )
 
     mass_matrix = _compatible_mass_matrix(oldf.mass_matrix, length(prob.u0))
@@ -83,6 +92,7 @@ function _initialized_problem_compatible(prob)
 end
 
 make_initialization_maps_compatible(prob, initprob, umap, pmap, p) = (umap, pmap)
+lower_initialization_problem(prob) = prob
 
 make_static_storage(x::StaticArrays.StaticArray) =
     StaticArrays.SArray{Tuple{size(x)...}}(map(make_static_storage, x))
@@ -165,6 +175,12 @@ function make_nonlinear_problem_compatible(prob::SciMLBase.NonlinearLeastSquares
         lb = nothing,
         ub = nothing,
         prob.kwargs...
+    )
+end
+
+function make_nonlinear_problem_compatible(prob::ImmutableSCCNonlinearProblem)
+    return ImmutableSCCNonlinearProblem(
+        make_nonlinear_problem_compatible(prob.problem), prob.blocks
     )
 end
 

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
@@ -136,9 +136,9 @@ end
 # Test 3: Non-square and bounded nonlinear least-squares initialization
 # ============================================================================
 
-function initialization_test_problem(initprob)
+function initialization_test_problem(initprob; metadata = nothing)
     initdata = SciMLBase.OverrideInitData(
-        initprob, nothing, sol -> sol.u, nothing, nothing, Val(false)
+        initprob, nothing, sol -> sol.u, nothing, metadata, Val(false)
     )
     f = SciMLBase.ODEFunction{false}(
         (u, p, t) -> zero(u); initialization_data = initdata
@@ -146,8 +146,8 @@ function initialization_test_problem(initprob)
     return SciMLBase.ODEProblem{false}(f, initprob.u0, (0.0f0, 0.1f0))
 end
 
-function solve_initialization_test(initprob)
-    prob = initialization_test_problem(initprob)
+function solve_initialization_test(initprob; metadata = nothing)
+    prob = initialization_test_problem(initprob; metadata)
     ensemble_prob = EnsembleProblem(prob, safetycopy = false)
     return solve(
         ensemble_prob, GPUTsit5(), EnsembleGPUKernel(backend);
@@ -199,6 +199,24 @@ end
     @test length(sol.u) == 2
     @test 0.0f0 < only(sol.u[1].u[1]) < 1.0f0
     @test sol.u[1].u[1] ≈ SA[0.75f0] atol = 1.0f-5
+end
+
+@testset "Immutable SCC initialization" begin
+    initprob = SciMLBase.ImmutableNonlinearProblem{false}(
+        (u, p) -> SA[u[1]^2 - 4.0f0, 3.0f0 * u[2] - u[1] - 1.0f0],
+        SA[1.0f0, 0.0f0]
+    )
+    metadata = DiffEqGPU.ImmutableSCCInitialization(
+        (
+            DiffEqGPU.ImmutableSCCBlock{1, 1, false}(),
+            DiffEqGPU.ImmutableSCCBlock{2, 1, true}(),
+        )
+    )
+    sol = solve_initialization_test(initprob; metadata)
+
+    @test length(sol.u) == 2
+    @test sol.u[1].u[1] ≈ SA[2.0f0, 1.0f0] atol = 1.0f-5
+    @test isbitstype(typeof(metadata))
 end
 
 # ============================================================================
@@ -255,12 +273,12 @@ end
 
     mtk_prob = ODEProblem(
         pendulum, [py => 0.99, D(px) => 0.0], (0.0, 1.0),
-        guesses = [pλ => 0.0, px => 0.1, D(py) => 0.0],
-        use_scc = false
+        guesses = [pλ => 0.0, px => 0.1, D(py) => 0.0]
     )
 
     @test SciMLBase.has_initialization_data(mtk_prob.f)
     @test mtk_prob.f.mass_matrix !== LinearAlgebra.I
+    @test mtk_prob.f.initialization_data.initializeprob isa SciMLBase.SCCNonlinearProblem
 
     compatible_prob = DiffEqGPU.make_prob_compatible(mtk_prob)
     @test isbitstype(typeof(compatible_prob))
@@ -268,6 +286,13 @@ end
     @test isbitstype(typeof(compatible_prob.f.initialization_data.initializeprob))
     @test compatible_prob.f.initialization_data.initializeprob isa
         SciMLBase.ImmutableNonlinearProblem
+    metadata = compatible_prob.f.initialization_data.metadata
+    @test metadata isa DiffEqGPU.ImmutableSCCInitialization
+    @test length(metadata.blocks) == 3
+    @test metadata.blocks[1] isa DiffEqGPU.ImmutableSCCBlock{1, 1, false}
+    @test metadata.blocks[2] isa DiffEqGPU.ImmutableSCCBlock{2, 1, true}
+    @test metadata.blocks[3] isa DiffEqGPU.ImmutableSCCBlock{3, 1, true}
+    @test isbitstype(typeof(metadata))
     @test compatible_prob.u0 == SVector{length(mtk_prob.u0)}(mtk_prob.u0)
 
     ref_sol = solve(mtk_prob, Rodas5P())
@@ -282,6 +307,6 @@ end
     )
     @test length(sol_mtk.u) == 2
     @test !any(isnan, sol_mtk.u[1].u[end])
-    @test norm(sol_mtk.u[1].u[1] - ref_sol.u[1]) < 1.0e-6
+    @test norm(sol_mtk.u[1].u[1] - ref_sol.u[1]) < 1.0e-5
     @test norm(sol_mtk.u[1].u[end] - ref_sol.u[end]) < 1.0
 end

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl
@@ -219,6 +219,54 @@ end
     @test isbitstype(typeof(metadata))
 end
 
+@testset "SCC initialization rejects non-triangular blocks" begin
+    # Row 1 depends on the downstream block, so the claimed SCC layout is wrong and the
+    # sequential solve leaves a nonzero full residual.
+    initprob = SciMLBase.ImmutableNonlinearProblem{false}(
+        (u, p) -> SA[u[1] - u[2], u[2] - 2.0f0],
+        SA[0.0f0, 0.0f0]
+    )
+    metadata = DiffEqGPU.ImmutableSCCInitialization(
+        (
+            DiffEqGPU.ImmutableSCCBlock{1, 1, true}(),
+            DiffEqGPU.ImmutableSCCBlock{2, 1, true}(),
+        )
+    )
+    sol = DiffEqGPU.solve_initialization_problem(
+        initprob, metadata, nothing, 1.0f-6, 1.0f-6
+    )
+    @test !SciMLBase.successful_retcode(sol)
+end
+
+@testset "Stateless all-linear SCC initialization" begin
+    @variables lscc_x lscc_y
+    linear_scc_sys = ModelingToolkit.complete(
+        ModelingToolkit.System(
+            [0 ~ 2.0f0 * lscc_x - 4.0f0, 0 ~ lscc_x + lscc_y - 5.0f0],
+            [lscc_x, lscc_y], []; name = :linear_scc_sys
+        )
+    )
+    # MTK's all-linear SCC problems can carry no state at all; the block contents are
+    # placeholders because the lowered solve only uses the flat residual.
+    linear_blocks = (
+        SciMLBase.LinearProblem(ones(Float32, 1, 1), zeros(Float32, 1)),
+        SciMLBase.LinearProblem(ones(Float32, 1, 1), zeros(Float32, 1)),
+    )
+    sccprob = SciMLBase.SCCNonlinearProblem(
+        linear_blocks, (Returns(nothing), Returns(nothing)); sys = linear_scc_sys
+    )
+    @test SciMLBase.state_values(sccprob) === nothing
+
+    lowered = DiffEqGPU.lower_initialization_problem(sccprob)
+    compat = DiffEqGPU.make_nonlinear_problem_compatible(lowered)
+    sol = DiffEqGPU.solve_initialization_problem(
+        compat.problem, DiffEqGPU.ImmutableSCCInitialization(compat.blocks),
+        nothing, 1.0f-6, 1.0f-6
+    )
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u ≈ SA[2.0f0, 3.0f0] atol = 1.0f-5
+end
+
 # ============================================================================
 # Test 4: Host symbolic setters and trivial initialization
 # ============================================================================

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -49,7 +49,7 @@ run_qa(
                 :DEFAULT_REDUCTION, :FINALIZE_DEFAULT, :INITIALIZE_DEFAULT,
                 :LeftRootFind, :NoRootFind, :RootfindOpt, :build_linear_solution,
                 :default_rng_func, :generate_sim_seeds, :solve_batch,
-                :specialization, :tighten_container_eltype,
+                :is_trivial_initialization, :specialization, :tighten_container_eltype,
                 # ForwardDiff differentiation API (documented but not `public`)
                 :Chunk, :Dual, :Partials, :construct_seeds, :derivative, :jacobian,
                 :npartials, :partials, :value,


### PR DESCRIPTION
## Summary

- lower ModelingToolkit `SCCNonlinearProblem` initialization to an immutable nonlinear problem plus statically typed SCC block metadata
- solve SCC blocks sequentially inside each GPU kernel trajectory while preserving the flattened MTK initialization state and parameter maps
- solve nonlinear SCC blocks with `SimpleTrustRegion`
- solve linear SCC blocks with a single exact Newton step in delta form (`u = u0 - J \ r0`, avoiding the `J * u0` cancellation) through the existing device-generic static square solver: closed-form for sizes 1-3 and pivoted LU for larger blocks
- support stateless all-linear SCC problems (`state_values === nothing`) by seeding missing linear-block states with zeros; the affine one-step solve is seed-independent, so nothing is lost. Stateless *nonlinear* blocks still error, since those genuinely need a guess
- require the full residual to vanish before reporting initialization success, so a block layout that is not actually triangular fails cleanly instead of returning a wrong state with `Success`
- keep mutable SCC cache writers and dynamic linear update wrappers off the device; the block Jacobian is re-derived from the flat residual via ForwardDiff because MTK's linear-block `A`/`b` come from mutable update functions of upstream solutions that would need per-trajectory re-evaluation on the device anyway
- reject SCCs containing Modelica homotopy blocks
- document and test mixed nonlinear/linear SCC initialization

The block/row-slicing invariant (block *k* of `probs` occupies states and residual rows `offset+1:offset+n` of the flat system) is guaranteed by MTK's construction: it reorders the stored system with `unknowns = dvs[vcat(var_sccs...)]` and `eqs = eqs[vcat(eq_sccs...)]` before building the `SCCNonlinearProblem`, and blocks are topologically sorted. The full-residual check guards this invariant at runtime for non-MTK-constructed problems.

A generic QR kernel is not required for SCC execution because structurally determined SCC blocks are square. QR remains relevant to a future numerically improved rectangular least-squares path, which is separate from this PR.

## Testing

`GROUP=JLArrays` on `test/gpu_kernel_de/stiff_ode/gpu_ode_modelingtoolkit_dae.jl`: all 14 testsets pass, including mixed immutable SCC (3/3), MTK pendulum SCC (19/19), and the two new discriminating testsets below. Repository QA: 27/27. JET: 75/75.

### Failing-before / passing-after evidence

**Non-triangular block layout falsely reported success.** With the full-residual check stashed, the new testset fails because the old code returns `Success` for a claimed SCC layout whose first row depends on the downstream block:

```
SCC initialization rejects non-triangular blocks: Test Failed at .../gpu_ode_modelingtoolkit_dae.jl:238
  Expression: !(SciMLBase.successful_retcode(sol))
Test Summary:                                    | Fail  Total  Time
SCC initialization rejects non-triangular blocks |    1      1  1.3s
```

**Stateless all-linear SCC problems errored instead of solving.** With the zero-seed support stashed, lowering a `SCCNonlinearProblem` built from stateless `LinearProblem` blocks throws:

```
ArgumentError: Every SCC initialization block must have an initial state for EnsembleGPUKernel.
 [3] lower_initialization_problem(prob::SCCNonlinearProblem{Nothing, false, ...})
   @ ModelingToolkitBaseExt ~/sandbox/DiffEqGPU.jl/ext/ModelingToolkitBaseExt.jl:51
```

With the fixes applied, both pass:

```
Test Summary:                                    | Pass  Total  Time
SCC initialization rejects non-triangular blocks |    1      1  0.1s
Test Summary:                           | Pass  Total  Time
Stateless all-linear SCC initialization |    3      3  8.7s
```

### CUDA caveat

CUDA compilation produces a valid `sm_61` cubin on the local GTX 1050 Ti. Its driver rejects module loading with `CUDA_ERROR_NOT_SUPPORTED` for kernels containing the square `SimpleTrustRegion` initialization path; the same rejection occurs in the existing bounded square-initialization test before SCC-specific code runs. Simpler DAE and rectangular-initialization CUDA kernels execute successfully on that machine.

Allowed-to-fail jobs (`julia pre`, GPU, downstream) were not run locally.

---

This PR should be ignored until reviewed by @ChrisRackauckas.
