### PR TITLE
Use runic on docs and fix up some other formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ prob = ODEProblem{false}(lorenz, u0, tspan, p)
 prob_func = (prob, ctx) -> remake(prob, p = (@SVector rand(Float32, 3)) .* p)
 monteprob = EnsembleProblem(prob, prob_func = prob_func, safetycopy = false)
 
-@time sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),
-    trajectories = 10_000, adaptive = false, dt = 0.1f0)
+@time sol = solve(
+    monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),
+    trajectories = 10_000, adaptive = false, dt = 0.1f0
+)
 ```
 
 ## Benchmarks

--- a/docs/src/examples/ad.md
+++ b/docs/src/examples/ad.md
@@ -30,24 +30,27 @@ u0 = Float32[3.0]
 
 function modelf(du, u, p, t)
     du[1] = 1.01f0 * u[1] * p[1] * p[2]
+    return
 end
 
 function model(p)
     prob = ODEProblem(modelf, u0, (0.0f0, 1.0f0), p)
 
     function prob_func(prob, ctx)
-        remake(prob, u0 = 0.5f0 .+ Float32(ctx.sim_id) / 100 .* prob.u0)
+        return remake(prob, u0 = 0.5f0 .+ Float32(ctx.sim_id) / 100 .* prob.u0)
     end
 
-    ensemble_prob = EnsembleProblem(prob, prob_func = prob_func)
-    solve(ensemble_prob, Tsit5(), EnsembleGPUArray(CUDA.CUDABackend()), saveat = 0.1f0,
-        trajectories = 10)
+    ensemble_prob = EnsembleProblem(prob; prob_func)
+    return solve(
+        ensemble_prob, Tsit5(), EnsembleGPUArray(CUDA.CUDABackend()),
+        saveat = 0.1f0, trajectories = 10
+    )
 end
 
 # loss function: run the Lux model to produce ODE parameters, then score the ensemble
 function loss(ps)
     p_vec, _ = dense(x, ps, st)
-    sum(abs2, 1.0f0 .- Array(model(p_vec)))
+    return sum(abs2, 1.0f0 .- Array(model(p_vec)))
 end
 
 println("Starting to train")
@@ -74,16 +77,22 @@ function lorenz(du, u, p, t)
     du[1] = p[1] * (u[2] - u[1])
     du[2] = u[1] * (p[2] - u[3]) - u[2]
     du[3] = u[1] * u[2] - p[3] * u[3]
+    return
 end
 
-u0 = [ForwardDiff.Dual(1.0f0, (1.0, 0.0, 0.0)), ForwardDiff.Dual(0.0f0, (0.0, 1.0, 0.0)),
-    ForwardDiff.Dual(0.0f0, (0.0, 0.0, 1.0))]
+u0 = [
+    ForwardDiff.Dual(1.0f0, (1.0, 0.0, 0.0)),
+    ForwardDiff.Dual(0.0f0, (0.0, 1.0, 0.0)),
+    ForwardDiff.Dual(0.0f0, (0.0, 0.0, 1.0)),
+]
 tspan = (0.0f0, 100.0f0)
 p = (10.0f0, 28.0f0, 8 / 3.0f0)
 prob = ODEProblem{true, SciMLBase.FullSpecialize}(lorenz, u0, tspan, p)
 prob_func = (prob, ctx) -> remake(prob, p = rand(Float32, 3) .* p)
-monteprob = EnsembleProblem(prob, prob_func = prob_func)
-@time sol = solve(monteprob, Tsit5(), EnsembleGPUArray(CUDA.CUDABackend()),
+monteprob = EnsembleProblem(prob; prob_func)
+@time sol = solve(
+    monteprob, Tsit5(), EnsembleGPUArray(CUDA.CUDABackend()),
     trajectories = 10_000,
-    saveat = 1.0f0)
+    saveat = 1.0f0
+)
 ```

--- a/docs/src/examples/bruss.md
+++ b/docs/src/examples/bruss.md
@@ -52,7 +52,7 @@ function init_brusselator_2d(xyd)
         u[i, j, 1] = 22 * (y * (1 - y))^(3 / 2)
         u[i, j, 2] = 27 * (x * (1 - x))^(3 / 2)
     end
-    u
+    return u
 end
 
 u0_cpu = init_brusselator_2d(xyd_brusselator)

--- a/docs/src/examples/gpu_ensemble_random_decay.md
+++ b/docs/src/examples/gpu_ensemble_random_decay.md
@@ -67,10 +67,12 @@ if CUDA.has_cuda() && CUDA.functional()
     # Use EnsembleGPUKernel with the CUDABackend.
     # GPUTsit5 is suitable for non-stiff ODEs on the GPU.
     # save_everystep=false reduces memory overhead and transfer time if only final states are needed.
-    gpu_sol = solve(ensemble_prob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend());
+    gpu_sol = solve(
+        ensemble_prob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend());
         trajectories = num_trajectories,
         save_everystep = false, # Crucial for performance measurement
-        dt = 0.01f0, adaptive = false)
+        dt = 0.01f0, adaptive = false
+    )
 else
     @warn "CUDA not available. Skipping GPU simulation."
     gpu_sol = nothing
@@ -81,10 +83,12 @@ end
 # Use EnsembleThreads for multi-threaded CPU execution.
 # Tsit5 is the CPU counterpart to GPUTsit5.
 # Match GPU saving options for fair comparison.
-cpu_sol = solve(ensemble_prob, Tsit5(), EnsembleThreads();
+cpu_sol = solve(
+    ensemble_prob, Tsit5(), EnsembleThreads();
     trajectories = num_trajectories,
     save_everystep = false, # Match GPU setting
-    dt = 0.01f0, adaptive = false)
+    dt = 0.01f0, adaptive = false
+)
 ```
 
 # Performance Comparison
@@ -95,18 +99,22 @@ We re-run the simulations using @time to get a cleaner measurement of the execut
 # --- GPU Timing (Second Run) ---
 if gpu_sol_perf !== nothing
     @info "Timing GPU simulation (second run, no data saving)..."
-    @time solve(ensemble_prob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend());
+    @time solve(
+        ensemble_prob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend());
         trajectories = num_trajectories, save_everystep = false,
-        dt = 0.01f0, adaptive = false)
+        dt = 0.01f0, adaptive = false
+    )
 else
     @info "Skipping GPU timing (CUDA not available)."
 end
 
 # --- CPU Timing (Second Run) ---
 @info "Timing CPU simulation (second run, no data saving)..."
-@time cpu_sol = solve(ensemble_prob, Tsit5(), EnsembleThreads();
+@time cpu_sol = solve(
+    ensemble_prob, Tsit5(), EnsembleThreads();
     trajectories = num_trajectories, save_everystep = false,
-    dt = 0.01f0, adaptive = false)
+    dt = 0.01f0, adaptive = false
+)
 
 # Note: The first @time includes compilation and setup, the second is more representative
 # of the pure computation time for subsequent runs. Expect GPU to be significantly
@@ -120,11 +128,13 @@ To visualize the evolution of the ensemble statistics (mean and standard deviati
 ```@example decay
 # Re-solve on CPU, saving all steps for plotting
 @info "Re-solving CPU simulation to collect data for plotting..."
-cpu_sol_plot = solve(ensemble_prob, Tsit5(), EnsembleThreads();
+cpu_sol_plot = solve(
+    ensemble_prob, Tsit5(), EnsembleThreads();
     trajectories = num_trajectories,
     save_everystep = true, # Save data at each dt step
     dt = 0.01f0,
-    adaptive = false)
+    adaptive = false
+)
 
 solutions_vector_cpu = cpu_sol_plot.u
 
@@ -151,7 +161,8 @@ end
 
 # Filter out failed trajectories (columns with NaN)
 successful_traj_indices_cpu = findall(
-    j -> !all(isnan, view(ensemble_vals_cpu, :, j)), 1:num_trajectories)
+    j -> !all(isnan, view(ensemble_vals_cpu, :, j)), 1:num_trajectories
+)
 num_successful_cpu = length(successful_traj_indices_cpu)
 
 if num_successful_cpu == 0
@@ -170,16 +181,20 @@ else
     p1_cpu = plot(
         t_vals_cpu, mean_u_cpu, ribbon = std_u_cpu, xlabel = "Time (t)", ylabel = "u(t)",
         title = "CPU Ensemble Mean ±1σ ($num_successful_cpu Trajectories)",
-        label = "Mean u(t)", fillalpha = 0.3, lw = 2)
+        label = "Mean u(t)", fillalpha = 0.3, lw = 2
+    )
 
     final_vals_cpu = ensemble_vals_cpu[end, :]
-    p2_cpu = histogram(final_vals_cpu, bins = 30, normalize = :probability,
+    p2_cpu = histogram(
+        final_vals_cpu, bins = 30, normalize = :probability,
         xlabel = "Final u(T)", ylabel = "Probability Density",
         title = "CPU Distribution of Final Values (t=$(tspan[2]))",
-        label = "", legend = false)
+        label = "", legend = false
+    )
 
     plot_cpu = plot(
-        p1_cpu, p2_cpu, layout = (1, 2), size = (1000, 450), legend = :outertopright)
+        p1_cpu, p2_cpu, layout = (1, 2), size = (1000, 450), legend = :outertopright
+    )
     @info "Displaying CPU analysis plot..."
     display(plot_cpu)
 end
@@ -200,7 +215,8 @@ if gpu_sol_perf !== nothing && CUDA.has_cuda() && CUDA.functional()
         trajectories = num_trajectories,
         save_everystep = true, # <<-- Save data at each dt step on GPU
         dt = 0.01f0,
-        adaptive = false)
+        adaptive = false
+    )
 
     # --- Data Transfer and Analysis ---
     # The result gpu_sol_plot should be an EnsembleSolution containing a Vector{ODESolution}
@@ -225,7 +241,8 @@ if gpu_sol_perf !== nothing && CUDA.has_cuda() && CUDA.functional()
     if solutions_vector !== nothing
         # Extract time points from the first successful trajectory's solution
         first_successful_gpu_idx = findfirst(
-            sol -> sol.retcode == ReturnCode.Success, solutions_vector)
+            sol -> sol.retcode == ReturnCode.Success, solutions_vector
+        )
 
         if first_successful_gpu_idx === nothing
             @error "No successful GPU trajectories found in the returned solutions vector!"
@@ -259,7 +276,8 @@ if gpu_sol_perf !== nothing && CUDA.has_cuda() && CUDA.functional()
 
             # Filter out failed trajectories (columns with NaN)
             successful_traj_indices_gpu = findall(
-                j -> !all(isnan, view(ensemble_vals_gpu, :, j)), 1:num_trajectories)
+                j -> !all(isnan, view(ensemble_vals_gpu, :, j)), 1:num_trajectories
+            )
             num_successful_gpu = length(successful_traj_indices_gpu)
 
             if num_successful_gpu == 0
@@ -277,19 +295,25 @@ if gpu_sol_perf !== nothing && CUDA.has_cuda() && CUDA.functional()
                 std_u_gpu = mapslices(std, ensemble_vals_gpu, dims = 2)[:]
 
                 # --- Plotting GPU Results ---
-                p1_gpu = plot(t_vals_gpu, mean_u_gpu, ribbon = std_u_gpu,
+                p1_gpu = plot(
+                    t_vals_gpu, mean_u_gpu, ribbon = std_u_gpu,
                     xlabel = "Time (t)", ylabel = "u(t)",
                     title = "GPU Ensemble Mean ±1σ ($num_successful_gpu Trajectories)",
-                    label = "Mean u(t)", fillalpha = 0.3, lw = 2)
+                    label = "Mean u(t)", fillalpha = 0.3, lw = 2
+                )
 
                 final_vals_gpu = ensemble_vals_gpu[end, :]
-                p2_gpu = histogram(final_vals_gpu, bins = 30, normalize = :probability,
+                p2_gpu = histogram(
+                    final_vals_gpu, bins = 30, normalize = :probability,
                     xlabel = "Final u(T)", ylabel = "Probability Density",
                     title = "GPU Distribution of Final Values (t=$(tspan[2]))",
-                    label = "", legend = false)
+                    label = "", legend = false
+                )
 
-                gpu_analysis_plot = plot(p1_gpu, p2_gpu, layout = (1, 2),
-                    size = (1000, 450), legend = :outertopright)
+                gpu_analysis_plot = plot(
+                    p1_gpu, p2_gpu, layout = (1, 2),
+                    size = (1000, 450), legend = :outertopright
+                )
                 @info "Displaying GPU analysis plot..."
                 display(gpu_analysis_plot)
 

--- a/docs/src/examples/reductions.md
+++ b/docs/src/examples/reductions.md
@@ -18,24 +18,29 @@ ra = rand(100)
 
 function f!(du, u, p, t)
     du[1] = 1.01 * u[1]
+    return
 end
 
 prob = ODEProblem(f!, [0.5], (0.0, 1.0))
 
 function output_func(sol, ctx)
-    last(sol), false
+    return last(sol), false
 end
 
 function prob_func(prob, ctx)
-    remake(prob, u0 = ra[ctx.sim_id] * prob.u0)
+    return remake(prob, u0 = ra[ctx.sim_id] * prob.u0)
 end
 
 function reduction(u, batch, I)
-    u .+ sum(batch), false
+    return u .+ sum(batch), false
 end
 
-prob2 = EnsembleProblem(prob, prob_func = prob_func, output_func = output_func,
-    reduction = reduction, u_init = Vector{eltype(prob.u0)}([0.0]))
-sim4 = solve(prob2, Tsit5(), EnsembleGPUArray(CUDA.CUDABackend()), trajectories = 100,
-    batch_size = 20)
+prob2 = EnsembleProblem(
+    prob; prob_func, output_func, reduction,
+    u_init = Vector{eltype(prob.u0)}([0.0])
+)
+sim4 = solve(
+    prob2, Tsit5(), EnsembleGPUArray(CUDA.CUDABackend()), trajectories = 100,
+    batch_size = 20
+)
 ```

--- a/docs/src/examples/sde.md
+++ b/docs/src/examples/sde.md
@@ -11,12 +11,14 @@ function lorenz(du, u, p, t)
     du[1] = p[1] * (u[2] - u[1])
     du[2] = u[1] * (p[2] - u[3]) - u[2]
     du[3] = u[1] * u[2] - p[3] * u[3]
+    return
 end
 
 function multiplicative_noise(du, u, p, t)
     du[1] = 0.1 * u[1]
     du[2] = 0.1 * u[2]
     du[3] = 0.1 * u[3]
+    return
 end
 
 CUDA.allowscalar(false)
@@ -26,8 +28,9 @@ p = (10.0f0, 28.0f0, 8 / 3.0f0)
 prob = SDEProblem(lorenz, multiplicative_noise, u0, tspan, p)
 const pre_p = [rand(Float32, 3) for i in 1:10_000]
 prob_func = (prob, ctx) -> remake(prob, p = pre_p[ctx.sim_id] .* p)
-monteprob = EnsembleProblem(prob, prob_func = prob_func)
+monteprob = EnsembleProblem(prob; prob_func)
 sol = solve(
     monteprob, SOSRI(), EnsembleGPUArray(CUDA.CUDABackend()), trajectories = 10_000,
-    saveat = 1.0f0)
+    saveat = 1.0f0
+)
 ```

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -87,8 +87,10 @@ prob = ODEProblem{false}(lorenz, u0, tspan, p)
 prob_func = (prob, ctx) -> remake(prob, p = (@SVector rand(Float32, 3)) .* p)
 monteprob = EnsembleProblem(prob, prob_func = prob_func, safetycopy = false)
 
-sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),
-    trajectories = 10_000)
+sol = solve(
+    monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),
+    trajectories = 10_000
+)
 ```
 
 To dig more into this example, see the [ensemble GPU solving tutorial](@ref lorenz).

--- a/docs/src/tutorials/gpu_ensemble_basic.md
+++ b/docs/src/tutorials/gpu_ensemble_basic.md
@@ -10,6 +10,7 @@ function lorenz(du, u, p, t)
     du[1] = p[1] * (u[2] - u[1])
     du[2] = u[1] * (p[2] - u[3]) - u[2]
     du[3] = u[1] * u[2] - p[3] * u[3]
+    return
 end
 
 u0 = Float32[1.0; 0.0; 0.0]
@@ -27,7 +28,8 @@ Changing this to being GPU-parallelized is as simple as changing the ensemble me
 ```@example lorenz
 sol = solve(
     monteprob, Tsit5(), EnsembleGPUArray(CUDA.CUDABackend()), trajectories = 10_000,
-    saveat = 1.0f0);
+    saveat = 1.0f0
+);
 ```
 
 and voilà, the method is re-compiled to parallelize the solves over a GPU!
@@ -56,9 +58,11 @@ p = @SVector [10.0f0, 28.0f0, 8 / 3.0f0]
 prob = ODEProblem{false}(lorenz2, u0, tspan, p)
 prob_func = (prob, ctx) -> remake(prob, p = (@SVector rand(Float32, 3)) .* p)
 monteprob = EnsembleProblem(prob, prob_func = prob_func, safetycopy = false)
-sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),
+sol = solve(
+    monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),
     trajectories = 10_000,
-    saveat = 1.0f0)
+    saveat = 1.0f0
+)
 ```
 
 Note that this form is also compatible with `EnsembleThreads()`, and `EnsembleGPUArray()`,
@@ -76,12 +80,8 @@ stiff ODE solver. Note that, as explained in the docstring, analytical derivativ
 
 ```@example lorenz
 function lorenz_jac(J, u, p, t)
-    σ = p[1]
-    ρ = p[2]
-    β = p[3]
-    x = u[1]
-    y = u[2]
-    z = u[3]
+    σ, ρ, β = p
+    x, y, z = u
     J[1, 1] = -σ
     J[2, 1] = ρ - z
     J[3, 1] = y
@@ -91,10 +91,11 @@ function lorenz_jac(J, u, p, t)
     J[1, 3] = 0
     J[2, 3] = -x
     J[3, 3] = -β
+    return
 end
 
 function lorenz_tgrad(J, u, p, t)
-    nothing
+    return nothing
 end
 
 u0 = Float32[1.0; 0.0; 0.0]
@@ -102,8 +103,10 @@ tspan = (0.0f0, 100.0f0)
 p = [10.0f0, 28.0f0, 8 / 3.0f0]
 func = ODEFunction(lorenz, jac = lorenz_jac, tgrad = lorenz_tgrad)
 prob_jac = ODEProblem(func, u0, tspan, p)
-monteprob_jac = EnsembleProblem(prob_jac, prob_func = prob_func)
+monteprob_jac = EnsembleProblem(prob_jac; prob_func)
 
-solve(monteprob_jac, Rodas5P(), EnsembleGPUArray(CUDA.CUDABackend()), trajectories = 10_000,
-    saveat = 1.0f0)
+solve(
+    monteprob_jac, Rodas5P(), EnsembleGPUArray(CUDA.CUDABackend()),
+    trajectories = 10_000, saveat = 1.0f0
+)
 ```

--- a/docs/src/tutorials/lower_level_api.md
+++ b/docs/src/tutorials/lower_level_api.md
@@ -39,23 +39,27 @@ probs = cu(probs)
 ## Finally use the lower API for faster solves! (Fixed time-stepping)
 
 # Run once for compilation
-@time CUDA.@sync ts,
-us = DiffEqGPU.vectorized_solve(probs, prob, GPUTsit5();
-    save_everystep = false, dt = 0.1f0)
+@time CUDA.@sync ts, us = DiffEqGPU.vectorized_solve(
+    probs, prob, GPUTsit5();
+    save_everystep = false, dt = 0.1f0
+)
 
-@time CUDA.@sync ts,
-us = DiffEqGPU.vectorized_solve(probs, prob, GPUTsit5();
-    save_everystep = false, dt = 0.1f0)
+@time CUDA.@sync ts, us = DiffEqGPU.vectorized_solve(
+    probs, prob, GPUTsit5();
+    save_everystep = false, dt = 0.1f0
+)
 
 ## Adaptive time-stepping
 # Run once for compilation
-@time CUDA.@sync ts,
-us = DiffEqGPU.vectorized_asolve(probs, prob, GPUTsit5();
-    save_everystep = false, dt = 0.1f0)
+@time CUDA.@sync ts, us = DiffEqGPU.vectorized_asolve(
+    probs, prob, GPUTsit5();
+    save_everystep = false, dt = 0.1f0
+)
 
-@time CUDA.@sync ts,
-us = DiffEqGPU.vectorized_asolve(probs, prob, GPUTsit5();
-    save_everystep = false, dt = 0.1f0)
+@time CUDA.@sync ts, us = DiffEqGPU.vectorized_asolve(
+    probs, prob, GPUTsit5();
+    save_everystep = false, dt = 0.1f0
+)
 ```
 
 Note that the core is the function `DiffEqGPU.vectorized_solve` which is the solver for the CUDA-based `probs`
@@ -96,11 +100,13 @@ end
 @time CUDA.@sync sol = DiffEqGPU.vectorized_map_solve(
     probs, Tsit5(), EnsembleGPUArray(0.0),
     batch, false, dt = 0.001f0,
-    save_everystep = false, dense = false)
+    save_everystep = false, dense = false
+)
 
 ## Adaptive time-stepping (Notice the boolean argument)
 @time CUDA.@sync sol = DiffEqGPU.vectorized_map_solve(
     probs, Tsit5(), EnsembleGPUArray(0.0),
     batch, true, dt = 0.001f0,
-    save_everystep = false, dense = false)
+    save_everystep = false, dense = false
+)
 ```

--- a/docs/src/tutorials/modelingtoolkit.md
+++ b/docs/src/tutorials/modelingtoolkit.md
@@ -26,20 +26,24 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 @parameters σ ρ β
 @variables x(t) y(t) z(t)
 
-eqs = [D(D(x)) ~ σ * (y - x),
+eqs = [
+    D(D(x)) ~ σ * (y - x),
     D(y) ~ x * (ρ - z) - y,
-    D(z) ~ x * y - β * z]
+    D(z) ~ x * y - β * z,
+]
 
 @named lorenz = System(eqs, t)
 sys = mtkcompile(lorenz; split = false)
 
-op = @SVector [D(x) => 2.0f0,
+op = @SVector [
+    D(x) => 2.0f0,
     x => 1.0f0,
     y => 0.0f0,
     z => 0.0f0,
     σ => 28.0f0,
     ρ => 10.0f0,
-    β => 8.0f0 / 3.0f0]
+    β => 8.0f0 / 3.0f0,
+]
 
 tspan = (0.0f0, 100.0f0)
 prob = ODEProblem{false}(sys, op, tspan)
@@ -97,12 +101,14 @@ we can build and solve an MTK generated ODE on the GPU using the following:
 using DiffEqGPU, CUDA
 function prob_func2(prob, ctx)
     u0, p = sym_setter(prob, SVector{3}(rand(Float32, 3)))
-    remake(prob, u0 = u0, p = p)
+    return remake(prob; u0, p)
 end
 
 monteprob = EnsembleProblem(prob, prob_func = prob_func2, safetycopy = false)
-sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),
-    trajectories = 10_000)
+sol = solve(
+    monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),
+    trajectories = 10_000
+)
 ```
 
 We can then using symbolic indexing on the result to inspect it:

--- a/docs/src/tutorials/multigpu.md
+++ b/docs/src/tutorials/multigpu.md
@@ -60,9 +60,11 @@ Let's solve 40,000 trajectories, batching 10,000 trajectories at a time:
 prob = ODEProblem(lorenz_distributed, u0, tspan, p)
 monteprob = EnsembleProblem(prob, prob_func = prob_func_distributed)
 
-@time sol2 = solve(monteprob, Tsit5(), EnsembleGPUArray(CUDA.CUDABackend()),
+@time sol2 = solve(
+    monteprob, Tsit5(), EnsembleGPUArray(CUDA.CUDABackend()),
     trajectories = 40_000,
-    batch_size = 10_000, saveat = 1.0f0)
+    batch_size = 10_000, saveat = 1.0f0
+)
 ```
 
 This will `pmap` over the batches, and thus if you have 4 processes each with
@@ -114,7 +116,9 @@ CUDA.allowscalar(false)
 prob = ODEProblem(lorenz_distributed, u0, tspan, p)
 monteprob = EnsembleProblem(prob, prob_func = prob_func_distributed)
 
-@time sol = solve(monteprob, Tsit5(), EnsembleGPUArray(CUDA.CUDABackend()),
+@time sol = solve(
+    monteprob, Tsit5(), EnsembleGPUArray(CUDA.CUDABackend()),
     trajectories = 100_000,
-    batch_size = 50_000, saveat = 1.0f0)
+    batch_size = 50_000, saveat = 1.0f0
+)
 ```

--- a/docs/src/tutorials/parallel_callbacks.md
+++ b/docs/src/tutorials/parallel_callbacks.md
@@ -17,8 +17,10 @@ affect!(integrator) = integrator.u += @SVector[10.0f0]
 
 gpu_cb = DiscreteCallback(condition, affect!; save_positions = (false, false))
 
-sol = solve(monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),
+sol = solve(
+    monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()),
     trajectories = 10,
     adaptive = false, dt = 0.01f0, callback = gpu_cb, merge_callbacks = true,
-    tstops = [4.0f0])
+    tstops = [4.0f0]
+)
 ```

--- a/docs/src/tutorials/weak_order_conv_sde.md
+++ b/docs/src/tutorials/weak_order_conv_sde.md
@@ -37,8 +37,10 @@ us_calc = reshape(mean(sol_array, dims = 3), size(sol_array, 2))
 us_expect = u₀ .* exp.(p[1] * ts)
 
 using Plots
-plot(ts, us_expect, lw = 5,
-    xaxis = "Time (t)", yaxis = "y(t)", label = "True Expected value")
+plot(
+    ts, us_expect, lw = 5,
+    xaxis = "Time (t)", yaxis = "y(t)", label = "True Expected value"
+)
 
 plot!(ts, us_calc, lw = 3, ls = :dash, label = "Calculated Expected value")
 ```

--- a/docs/src/tutorials/within_method_gpu.md
+++ b/docs/src/tutorials/within_method_gpu.md
@@ -8,7 +8,7 @@ accelerated simply by placing the initial condition array on the GPU. As a quick
 ```@example within_gpu
 using OrdinaryDiffEq, CUDA, LinearAlgebra
 function f(du, u, p, t)
-    mul!(du, A, u)
+    return mul!(du, A, u)
 end
 
 A = cu(-rand(3, 3))

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -100,8 +100,10 @@ containers for `EnsembleGPUKernel`. Implementations must support the lower-level
 # Examples
 
 ```julia
-solve(ensemble_prob, GPUTsit5(), EnsembleGPUKernel(backend);
-    trajectories = 10_000, adaptive = false, dt = 0.1f0)
+solve(
+    ensemble_prob, GPUTsit5(), EnsembleGPUKernel(backend);
+    trajectories = 10_000, adaptive = false, dt = 0.1f0
+)
 ```
 """
 abstract type EnsembleKernelAlgorithm <: SciMLBase.EnsembleAlgorithm end
@@ -151,8 +153,10 @@ host-side behavior.
 # Examples
 
 ```julia
-DiffEqGPU.vectorized_solve(gpu_probs, sde_prob, GPUEM();
-    dt = 0.01f0, save_everystep = false)
+DiffEqGPU.vectorized_solve(
+    gpu_probs, sde_prob, GPUEM();
+    dt = 0.01f0, save_everystep = false
+)
 ```
 """
 abstract type GPUSDEAlgorithm <: SciMLBase.AbstractSDEAlgorithm end
@@ -166,7 +170,7 @@ Developer interface for stiff ODE algorithms in the `EnsembleGPUKernel` path.
 
   - `AD`: Boolean-like type parameter indicating whether the algorithm may derive missing
     Jacobian and time-gradient information with automatic differentiation. Constructors
-    accept `autodiff = Val{true}()` or `Val{false}()`.
+    accept `autodiff = Val(true)` or `Val(false)`.
 
 # Interface Rules
 
@@ -180,8 +184,10 @@ DiffEqGPU's GPU-compatible linear algebra utilities.
 # Examples
 
 ```julia
-solve(ensemble_prob, GPURodas4(autodiff = Val{false}()),
-    EnsembleGPUKernel(backend); trajectories = 10_000)
+solve(
+    ensemble_prob, GPURodas4(autodiff = Val(false)),
+    EnsembleGPUKernel(backend); trajectories = 10_000
+)
 ```
 """
 abstract type GPUODEImplicitAlgorithm{AD} <: GPUODEAlgorithm end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -95,6 +95,7 @@ function lorenz(du, u, p, t)
     du[1] = p[1] * (u[2] - u[1])
     du[2] = u[1] * (p[2] - u[3]) - u[2]
     du[3] = u[1] * u[2] - p[3] * u[3]
+    return
 end
 
 u0 = Float32[1.0; 0.0; 0.0]
@@ -102,9 +103,11 @@ tspan = (0.0f0, 100.0f0)
 p = [10.0f0, 28.0f0, 8 / 3.0f0]
 prob = ODEProblem(lorenz, u0, tspan, p)
 prob_func = (prob, ctx) -> remake(prob, p = rand(Float32, 3) .* p)
-monteprob = EnsembleProblem(prob, prob_func = prob_func, safetycopy = false)
-@time sol = solve(monteprob, Tsit5(), EnsembleGPUArray(CUDADevice()),
-    trajectories = 10_000, saveat = 1.0f0)
+monteprob = EnsembleProblem(prob; prob_func, safetycopy = false)
+@time sol = solve(
+    monteprob, Tsit5(), EnsembleGPUArray(CUDADevice()),
+    trajectories = 10_000, saveat = 1.0f0
+)
 ```
 """
 struct EnsembleGPUArray{Backend} <: EnsembleArrayAlgorithm
@@ -147,18 +150,18 @@ right-hand sides, callbacks, or solver combinations throw when the ensemble is s
     capable of being compiled into a GPU kernel are allowed. This notably means that
     certain features of Julia can cause issues inside a kernel, like:
 
-      + Allocating memory (building arrays)
-      + Linear algebra (anything that calls BLAS)
-      + Broadcast
+    + Allocating memory (building arrays)
+    + Linear algebra (anything that calls BLAS)
+    + Broadcast
 
   - Only out-of-place `f` definitions are allowed. Coupled with the requirement of not
     allowing for memory allocations, this means that the ODE must be defined with
     `StaticArray` initial conditions.
   - Only specific ODE solvers are allowed. This includes:
 
-      + GPUTsit5
-      + GPUVern7
-      + GPUVern9
+    + GPUTsit5
+    + GPUVern7
+    + GPUVern9
   - To use multiple GPUs over clusters, one must manually set up one process per GPU. See
     the multi-GPU tutorial for more details.
 
@@ -186,7 +189,8 @@ monteprob = EnsembleProblem(prob, prob_func = prob_func, safetycopy = false)
 
 @time sol = solve(
     monteprob, GPUTsit5(), EnsembleGPUKernel(CUDA.CUDABackend()), trajectories = 10_000,
-    adaptive = false, dt = 0.1f0)
+    adaptive = false, dt = 0.1f0
+)
 ```
 """
 struct EnsembleGPUKernel{Dev} <: EnsembleKernelAlgorithm

--- a/src/ensemblegpuarray/lowerlevel_solve.jl
+++ b/src/ensemblegpuarray/lowerlevel_solve.jl
@@ -1,6 +1,8 @@
 """
-    vectorized_map_solve(probs, alg, ensemblealg::EnsembleArrayAlgorithm, I, adaptive;
-        kwargs...)
+    vectorized_map_solve(
+        probs, alg, ensemblealg::EnsembleArrayAlgorithm, I, adaptive;
+        kwargs...
+    )
 
 Run the `EnsembleArrayAlgorithm` path directly for a selected set of trajectories. The
 function is intended for solver and ensemble package developers that need the lower-level

--- a/src/ensemblegpukernel/lowerlevel_solve.jl
+++ b/src/ensemblegpukernel/lowerlevel_solve.jl
@@ -1,7 +1,9 @@
 """
-    vectorized_solve(probs, prob::Union{ODEProblem, SDEProblem}, alg; dt,
+    vectorized_solve(
+        probs, prob::Union{ODEProblem, SDEProblem}, alg; dt,
         saveat = nothing, save_everystep = true, debug = false,
-        callback = CallbackSet(nothing), tstops = nothing)
+        callback = CallbackSet(nothing), tstops = nothing
+    )
 
 Run a fixed-step `EnsembleGPUKernel` solve on a batch of compatible problems. This is a
 developer-facing entry point for packages that need the batched time and state arrays
@@ -199,10 +201,12 @@ function vectorized_solve(
 end
 
 """
-    vectorized_asolve(probs, prob::ODEProblem, alg; dt = 0.1f0,
+    vectorized_asolve(
+        probs, prob::ODEProblem, alg; dt = 0.1f0,
         saveat = nothing, save_everystep = false, abstol = 1.0f-6,
         reltol = 1.0f-3, debug = false, callback = CallbackSet(nothing),
-        tstops = nothing)
+        tstops = nothing
+    )
 
 Run an adaptive `EnsembleGPUKernel` ODE solve on a batch of compatible problems. This is a
 developer-facing entry point for packages that need the batched time and state arrays


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Uses runic on docs (using `--docstrings and --extensions=jl,md` on the runic CLI app) and reformats some lines for easier reading.
