### PR TITLE
Apply Runic 1.10 formatting to src/solve.jl

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -255,30 +255,30 @@ function batch_solve(
             )
             [
                 begin
-                        ts = @view solts[:, i]
-                        us = @view solus[:, i]
-                        sol_idx = findlast(x -> x != probs[i].tspan[1], ts)
-                        if sol_idx === nothing
-                            @error "No solution found" tspan = probs[i].tspan[1] ts
-                            error("Batch solve failed")
+                    ts = @view solts[:, i]
+                    us = @view solus[:, i]
+                    sol_idx = findlast(x -> x != probs[i].tspan[1], ts)
+                    if sol_idx === nothing
+                        @error "No solution found" tspan = probs[i].tspan[1] ts
+                        error("Batch solve failed")
                     end
-                        @views ensembleprob.output_func(
-                            SciMLBase.build_solution(
-                                probs[i],
-                                alg,
-                                ts[1:sol_idx],
-                                us[1:sol_idx],
-                                k = nothing,
-                                stats = nothing,
-                                calculate_error = false,
-                                retcode = sol_idx !=
+                    @views ensembleprob.output_func(
+                        SciMLBase.build_solution(
+                            probs[i],
+                            alg,
+                            ts[1:sol_idx],
+                            us[1:sol_idx],
+                            k = nothing,
+                            stats = nothing,
+                            calculate_error = false,
+                            retcode = sol_idx !=
                                 length(ts) ?
                                 ReturnCode.Terminated :
                                 ReturnCode.Success
-                            ),
-                            _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
-                        )[1]
-                    end
+                        ),
+                        _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
+                    )[1]
+                end
                     for i in eachindex(probs)
             ]
 
@@ -334,22 +334,22 @@ function batch_solve(
 
             [
                 ensembleprob.output_func(
-                        SciMLBase.build_solution(
-                            probs[i], alg,
-                            map(
-                                t -> probs[i].tspan[1] +
+                    SciMLBase.build_solution(
+                        probs[i], alg,
+                        map(
+                            t -> probs[i].tspan[1] +
                                 (
-                                    probs[i].tspan[2] -
+                                probs[i].tspan[2] -
                                     probs[i].tspan[1]
-                                ) *
+                            ) *
                                 t,
-                                sol.t
-                            ), solus[i],
-                            stats = sol.stats,
-                            retcode = sol.retcode
-                        ),
-                        _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
-                    )[1]
+                            sol.t
+                        ), solus[i],
+                        stats = sol.stats,
+                        retcode = sol.retcode
+                    ),
+                    _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
+                )[1]
                     for i in 1:length(probs)
             ]
         else
@@ -365,14 +365,14 @@ function batch_solve(
             )
             [
                 ensembleprob.output_func(
-                        SciMLBase.build_solution(
-                            probs[i], alg, sol.t,
-                            solus[i],
-                            stats = sol.stats,
-                            retcode = sol.retcode
-                        ),
-                        _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
-                    )[1]
+                    SciMLBase.build_solution(
+                        probs[i], alg, sol.t,
+                        solus[i],
+                        stats = sol.stats,
+                        retcode = sol.retcode
+                    ),
+                    _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
+                )[1]
                     for i in 1:length(probs)
             ]
         end


### PR DESCRIPTION
## Summary

Whitespace-only reformat of `src/solve.jl` (41+/41−, `git diff -w` is empty). A Runic release after master's last green format-check run (2026-08-28, `26aa6bb`) tightened an indentation rule, so every new CI run now fails the format check repo-wide — including PRs that do not touch this file (e.g. https://github.com/SciML/DiffEqGPU.jl/pull/511). This is the only file that drifts: `runic --check` over all 73 tracked `.jl` files flags `src/solve.jl` alone.

Formatting only — no behavior change, per the mechanical-changes-ship-alone rule.

## Verification

- `runic --check src/solve.jl` (Runic v1.10.0, the version CI resolves): fails before, passes after.
- `git diff -w --stat` empty: whitespace-only.
- `typos src/solve.jl`: clean.
- `GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`: 26/27. The single error is **pre-existing on master and unrelated to this diff**: ExplicitImports flags the non-public `SciMLBase.is_trivial_initialization` access introduced by #510 (master's Tests workflow is currently red on exactly this QA job: https://github.com/SciML/DiffEqGPU.jl/actions/runs/33171640033). PR #511 carries the one-line QA ignore fix.
- GPU/AMDGPU jobs not run locally; AMDGPU CI is independently failing on master, tracked in https://github.com/SciML/DiffEqGPU.jl/issues/513.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
