### PR TITLE
Bump to 3.20.0 for the SCC initialization feature

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqGPU"
 uuid = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 authors = ["Chris Rackauckas", "SciML"]
-version = "3.19.1"
+version = "3.20.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/tutorials/modelingtoolkit.md
+++ b/docs/src/tutorials/modelingtoolkit.md
@@ -175,7 +175,9 @@ The current initialization path has the following restrictions:
     traces those operations on the host and stores only static gather recipes in the
     kernel. Fallback getters that evaluate derived symbolic expressions are not yet
     lowered.
-  - Ordinary nonlinear and linear SCC initialization blocks are supported. SCC
+  - Ordinary nonlinear and linear SCC initialization blocks are supported, including
+    all-linear SCC problems that carry no initial state: missing linear-block states are
+    seeded with zeros, which the exact one-step linear solve does not depend on. SCC
     initialization containing Modelica homotopy blocks is not supported.
 
 Structured `MTKParameters` storage is converted recursively to static storage, so this


### PR DESCRIPTION
## Summary

- `Project.toml` version `3.19.1` → `3.20.0`: https://github.com/SciML/DiffEqGPU.jl/pull/511 merged new public functionality (MTK SCC initialization on GPU kernels) while master still carried the released `3.19.1`, so registration needs a minor bump.
- Documents the stateless all-linear SCC support (zero-seeded linear blocks) in the ModelingToolkit tutorial's restrictions list.

## Verification

- `typos` on both changed files: clean.
- Local docs build (`julia --project=docs docs/make.jl`): the edited page `docs/src/tutorials/modelingtoolkit.md` builds with no errors. The build as a whole fails only on CUDA `@example` blocks in *other, untouched* pages (`getting_started.md`, `gpu_ensemble_basic.md`, …), which cannot execute on this machine's GTX 1050 Ti (`CUDA error: operation not supported (code 801)` — the known Pascal driver limitation). The Documentation CI job on a supported GPU runner is the arbiter for those pages.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
