### PR TITLE
Fix scalar indexing in EnsembleGPUArray continuous callbacks

### DIFF
--- a/src/ensemblegpuarray/callbacks.jl
+++ b/src/ensemblegpuarray/callbacks.jl
@@ -20,10 +20,13 @@ function generate_callback(callback::ContinuousCallback, I, ensemblealg)
     affect! = function (integrator, simultaneous_events::AbstractVector)
         version = get_backend(integrator.u)
         wgs = workgroupsize(version, size(integrator.u, 2))
+        # DiffEqBase passes a `@view` of its host mask buffer. GPU backends only have a
+        # memcpy path for `Array` sources, so materialize the view to avoid scalar indexing.
+        host_events = convert(Vector{eltype(simultaneous_events)}, simultaneous_events)
         simultaneous_events_device = similar(
-            integrator.u, eltype(simultaneous_events), length(simultaneous_events)
+            integrator.u, eltype(host_events), length(host_events)
         )
-        copyto!(simultaneous_events_device, simultaneous_events)
+        copyto!(simultaneous_events_device, host_events)
         return continuous_affect!_kernel(version)(
             _affect!, _affect_neg!, simultaneous_events_device, integrator.u,
             integrator.t, integrator.p;

--- a/test/callback_event_detection.jl
+++ b/test/callback_event_detection.jl
@@ -1,4 +1,6 @@
-using DiffEqGPU, JLArrays, Test
+using DiffEqGPU, JLArrays, GPUArraysCore, Test
+
+GPUArraysCore.allowscalar(false)
 
 @testset "continuous callback direction dispatch" begin
     affect!(integrator) = (integrator.u[1] += 10)
@@ -7,9 +9,15 @@ using DiffEqGPU, JLArrays, Test
         (u, t, integrator) -> u[1], affect!, affect_neg!
     )
     vector_callback = DiffEqGPU.generate_callback(callback, 3, nothing)
-    u = JLArray(reshape(Float32[1, 2, 3], 1, :))
-    integrator = (; u, t = 0.0f0, p = zero(u))
 
-    vector_callback.affect!(integrator, Int8[1, -1, 0])
-    @test Array(u) == reshape(Float32[11, -8, 3], 1, :)
+    # DiffEqBase hands the affect a `@view` of its `Vector{Int8}` mask buffer, so the
+    # view form is the one real solves exercise.
+    masks = (Int8[1, -1, 0], @view(Int8[1, -1, 0, 0][1:3]))
+    @testset "mask::$(typeof(mask))" for mask in masks
+        u = JLArray(reshape(Float32[1, 2, 3], 1, :))
+        integrator = (; u, t = 0.0f0, p = zero(u))
+
+        vector_callback.affect!(integrator, mask)
+        @test Array(u) == reshape(Float32[11, -8, 3], 1, :)
+    end
 end


### PR DESCRIPTION
> **Note:** this PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

The AMDGPU Buildkite jobs on master have been red since DiffEqBase 7.19 landed, and the CUDA GitHub GPU job fails the same way — this is not an AMD-specific problem. DiffEqBase's `apply_callback!` hands the generated `VectorContinuousCallback` affect a `@view(simultaneous_events[1:len])` of its host `Vector{Int8}` mask (DiffEqBase `src/callbacks.jl:594`). GPUArrays only provides memcpy `copyto!` paths for `Array` sources, so `copyto!(::ROCArray, ::SubArray{Int8,1,Vector{Int8}})` fell through to `Base.copyto_unaliased!` and raised `Scalar indexing is disallowed` on the first continuous-callback event (`src/ensemblegpuarray/callbacks.jl:26`, reached from `test/ensemblegpuarray.jl:141`).

The fix converts the mask to a `Vector` before the device copy (a no-op when it already is one). The existing JLArrays regression from #503 only passed a plain `Vector`, so it never exercised the view path; it now runs both forms.

## Master CI evidence

- AMDGPU Julia 1.12 (build 1569): https://buildkite.com/julialang/diffeqgpu-dot-jl/builds/1569#01a0485d-81d8-44f1-905c-6197243b9e5b — `LoadError: Scalar indexing is disallowed.` … `copyto_unaliased!(…, dest::AMDGPU.ROCArray{Int8, 1, …}, …, src::SubArray{Int8, 1, Vector{Int8}, Tuple{UnitRange{Int64}}, true})` … `@ DiffEqGPU …/src/ensemblegpuarray/callbacks.jl:26`
- Same signature on AMDGPU 1.10 in build 1562 and on AMDGPU 1.12 in builds 1555/1558.
- CUDA Julia 1 on master (26aa6bb): https://github.com/SciML/DiffEqGPU.jl/actions/runs/33171639622/job/98849973864 — `EnsembleGPUArray: Error During Test … LoadError: Scalar indexing is disallowed.`
- Two other AMDGPU failures in the recent history are unrelated to this change: build 1545 failed with `no method matching findall_events!(::ROCArray, ::ROCArray)` on DiffEqBase 7.18.2 (fixed by the 7.19 floor in #503), and build 1569's Julia 1.10 job died in `Pkg.Registry.update` with a LibGit2 `invalid value for Enum Code: -30848` (registry fetch on the agent, infrastructure).

The test at `test/ensemblegpuarray.jl:141` uses randomly scaled Lorenz parameters, so whether a `u[1] - 3` crossing occurs varies run to run — that is why build 1555's AMDGPU 1.10 job passed while its 1.12 sibling failed.

## Verification

Failing before / passing after, with the new JLArrays test (`GPUArraysCore.allowscalar(false)`), Julia 1.10.11:

Unfixed source (`git stash push src/`):
```
mask::SubArray{Int8, 1, Vector{Int8}, Tuple{UnitRange{Int64}}, true}: Error During Test at .../test/callback_event_detection.jl:16
  Scalar indexing is disallowed.
Test Summary:                                                          | Pass  Error  Total  Time
continuous callback direction dispatch                                 |    1      1      2  3.2s
  mask::Vector{Int8}                                                   |    1             1  1.4s
  mask::SubArray{Int8, 1, Vector{Int8}, Tuple{UnitRange{Int64}}, true} |           1      1  1.6s
ERROR: LoadError: Some tests did not pass: 1 passed, 0 failed, 1 errored, 0 broken.
```

With the fix:
```
Test Summary:                          | Pass  Total  Time
continuous callback direction dispatch |    2      2  1.8s
```

`GROUP=JLArrays julia --project -e 'using Pkg; Pkg.test()'`:
```
GPU Kernelized Stiff ODE Mass Matrix |    2      2  5m37.0s
GPU Kernelized DAE Mass Matrix |   63     63  14m46.3s
GPU Kernelized Non Stiff ODE Regression |   48     48  33.6s
GPU Kernelized Non Stiff ODE DiscreteCallback |   78     78  37.6s
GPU Kernelized Stiff ODE Regression |   75     75  45.5s
GPU Kernelized Stiff ODE DiscreteCallback |   46     46  30.7s
GPU Kernelized ForwardDiff tests |     0  1m00.2s
GPU Kernelized FiniteDiff tests |    5      5  12.5s
GPU Kernelized Auto-Conversion tests |    6      6  8.7s
GPU callback event detection |    2      2  1.0s
     Testing DiffEqGPU tests passed
```

`GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`:
```
Quality Assurance |   27     27  2m04.9s
JET static analysis |   75     75  19.9s
     Testing DiffEqGPU tests passed
```

Runic check on the two changed files: clean. `typos`: clean.

## Not verified locally

No GPU on this machine. The actual CUDA/AMDGPU/Metal/oneAPI runs come from this PR's CI; I will read them and follow up here. Docs not rebuilt (no docstring or public API touched).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5)

https://claude.ai/code/session_01KUEcZZaLyM8qwBMimFeAUQ
