### PR TITLE
Reformat src/solve.jl for Runic 1.10

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -255,30 +255,30 @@ function batch_solve(
             )
             [
                 begin
-                        ts = @view solts[:, i]
-                        us = @view solus[:, i]
-                        sol_idx = findlast(x -> x != probs[i].tspan[1], ts)
-                        if sol_idx === nothing
-                            @error "No solution found" tspan = probs[i].tspan[1] ts
-                            error("Batch solve failed")
+                    ts = @view solts[:, i]
+                    us = @view solus[:, i]
+                    sol_idx = findlast(x -> x != probs[i].tspan[1], ts)
+                    if sol_idx === nothing
+                        @error "No solution found" tspan = probs[i].tspan[1] ts
+                        error("Batch solve failed")
                     end
-                        @views ensembleprob.output_func(
-                            SciMLBase.build_solution(
-                                probs[i],
-                                alg,
-                                ts[1:sol_idx],
-                                us[1:sol_idx],
-                                k = nothing,
-                                stats = nothing,
-                                calculate_error = false,
-                                retcode = sol_idx !=
+                    @views ensembleprob.output_func(
+                        SciMLBase.build_solution(
+                            probs[i],
+                            alg,
+                            ts[1:sol_idx],
+                            us[1:sol_idx],
+                            k = nothing,
+                            stats = nothing,
+                            calculate_error = false,
+                            retcode = sol_idx !=
                                 length(ts) ?
                                 ReturnCode.Terminated :
                                 ReturnCode.Success
-                            ),
-                            _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
-                        )[1]
-                    end
+                        ),
+                        _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
+                    )[1]
+                end
                     for i in eachindex(probs)
             ]
 
@@ -334,22 +334,22 @@ function batch_solve(
 
             [
                 ensembleprob.output_func(
-                        SciMLBase.build_solution(
-                            probs[i], alg,
-                            map(
-                                t -> probs[i].tspan[1] +
+                    SciMLBase.build_solution(
+                        probs[i], alg,
+                        map(
+                            t -> probs[i].tspan[1] +
                                 (
-                                    probs[i].tspan[2] -
+                                probs[i].tspan[2] -
                                     probs[i].tspan[1]
-                                ) *
+                            ) *
                                 t,
-                                sol.t
-                            ), solus[i],
-                            stats = sol.stats,
-                            retcode = sol.retcode
-                        ),
-                        _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
-                    )[1]
+                            sol.t
+                        ), solus[i],
+                        stats = sol.stats,
+                        retcode = sol.retcode
+                    ),
+                    _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
+                )[1]
                     for i in 1:length(probs)
             ]
         else
@@ -365,14 +365,14 @@ function batch_solve(
             )
             [
                 ensembleprob.output_func(
-                        SciMLBase.build_solution(
-                            probs[i], alg, sol.t,
-                            solus[i],
-                            stats = sol.stats,
-                            retcode = sol.retcode
-                        ),
-                        _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
-                    )[1]
+                    SciMLBase.build_solution(
+                        probs[i], alg, sol.t,
+                        solus[i],
+                        stats = sol.stats,
+                        retcode = sol.retcode
+                    ),
+                    _make_ensemble_context(I[i], sim_seeds, rng_func, master_rng)
+                )[1]
                     for i in 1:length(probs)
             ]
         end


### PR DESCRIPTION
> **Note:** this PR should be ignored until reviewed by @ChrisRackauckas.

Formatting-only. The Runic format check on master has been failing since the runic-action moved to Runic v1.10.0 (e.g. https://github.com/SciML/DiffEqGPU.jl/actions/runs/33262421716 on dc12c74 and https://github.com/SciML/DiffEqGPU.jl/actions/runs/33264846720 on #517), which flags `src/solve.jl` — a file untouched since the Runic migration — for the indentation of `begin` blocks inside comprehensions. Runic v1.7 accepts the old layout, which is why local checks passed.

## Verification

- `julia --project=<env with Runic v1.10.0> -e 'using Runic; Runic.main(["--check", "."])'` on master: exits 1, flags only `src/solve.jl`. After `--inplace`: exits 0.
- `git diff -w` is empty: the change is whitespace-only (41 lines re-indented, no token changes).
- No tests run: whitespace-only diff, nothing to exercise.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5)

https://claude.ai/code/session_01KUEcZZaLyM8qwBMimFeAUQ
