### PR TITLE
Document ImmutableSCCNonlinearProblem in the developer manual

### DIFF
--- a/docs/src/manual/developer_interfaces.md
+++ b/docs/src/manual/developer_interfaces.md
@@ -41,6 +41,12 @@ DiffEqGPU.AbstractNLSolverCache
 DiffEqGPU.NLSolver
 ```
 
+## Kernel DAE Initialization
+
+```@docs
+DiffEqGPU.ImmutableSCCNonlinearProblem
+```
+
 ## Lower-Level Solve Interfaces
 
 These entry points drive the kernel and array solver paths directly, without constructing


### PR DESCRIPTION
> **Note:** this PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

The Documentation job on master fails since #511 (dc12c74) with

```
┌ Error: 1 docstring not included in the manual:
│     DiffEqGPU.ImmutableSCCNonlinearProblem
ERROR: LoadError: `makedocs` encountered an error [:missing_docs] -- terminating build before rendering.
```
(https://github.com/SciML/DiffEqGPU.jl/actions/runs/33262421507/job/99126533735)

`ImmutableSCCNonlinearProblem` (`src/ensemblegpukernel/nlsolve/initialization.jl`) got a docstring in #511 but no `@docs` entry, and `docs/make.jl` checks all of `DiffEqGPU`. This adds it to `docs/src/manual/developer_interfaces.md` under a new "Kernel DAE Initialization" heading, next to the kernel nonlinear-solver internals it belongs with. Docs-only; no source change.

## Verification

- `typos` on the changed file: clean.
- A local `julia --project=docs docs/make.jl` is running now; I will post its output here when it finishes. The Documentation job on this PR is the authoritative check.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5)

https://claude.ai/code/session_01KUEcZZaLyM8qwBMimFeAUQ
