### PR TITLE
Stop master GPU workflow runs cancelling each other

### DIFF
--- a/.github/workflows/GPU.yml
+++ b/.github/workflows/GPU.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch && !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   cuda-tests:


### PR DESCRIPTION
> **Note:** this PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

`GPU.yml` had

```yaml
cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
```

`github.ref != 'refs/tags/v*'` is a literal string comparison (no globbing in expressions), so it is true for every ref and the whole expression is always `true`. Every master push therefore cancelled the in-progress master run of "CUDA Tests & Docs" — the last four master runs were all cancelled this way:

- https://github.com/SciML/DiffEqGPU.jl/actions/runs/33276386610 (f282e93)
- https://github.com/SciML/DiffEqGPU.jl/actions/runs/33276405449 (1aed545)
- https://github.com/SciML/DiffEqGPU.jl/actions/runs/33277402201 (6f88043)
- https://github.com/SciML/DiffEqGPU.jl/actions/runs/33106397284 (a07991d)

This restores the evident intent: cancel superseded runs on PR/feature refs, never on the default branch or on tags:

```yaml
cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch && !startsWith(github.ref, 'refs/tags/') }}
```

(`CI.yml` uses the simpler `github.ref != 'refs/heads/master'`; this keeps the default-branch/tag form the file already had.)

## Verification

- YAML parses. Not runnable locally; the observable effect is that consecutive master pushes both complete instead of the earlier one showing `cancelled`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5)

https://claude.ai/code/session_01KUEcZZaLyM8qwBMimFeAUQ
