### PR TITLE
Docs: recommend FullSpecialize for ModelingToolkit initialization on GPU kernels

### DIFF
--- a/docs/src/tutorials/modelingtoolkit.md
+++ b/docs/src/tutorials/modelingtoolkit.md
@@ -134,7 +134,7 @@ linear-problem update wrappers are not placed in the kernel.
 For example, the Cartesian pendulum can be initialized and solved as follows:
 
 ```julia
-using CUDA, DiffEqGPU, ModelingToolkit, OrdinaryDiffEq
+using CUDA, DiffEqGPU, ModelingToolkit, OrdinaryDiffEq, SciMLBase
 using ModelingToolkit: t_nounits as t, D_nounits as D
 
 @parameters g = 9.81 L = 1.0
@@ -148,7 +148,7 @@ eqs = [
 
 @mtkcompile pendulum = ODESystem(eqs, t, [px, py, pλ], [g, L])
 
-prob = ODEProblem(
+prob = ODEProblem{true, SciMLBase.FullSpecialize}(
     pendulum,
     [py => 0.99, D(px) => 0.0],
     (0.0, 1.0);
@@ -165,6 +165,21 @@ sol = solve(
     adaptive = false,
 )
 ```
+
+### Specialization level
+
+Construct ModelingToolkit problems intended for `EnsembleGPUKernel` initialization with
+`SciMLBase.FullSpecialize`, passed as the problem type parameter as above
+(`ODEProblem{iip, SciMLBase.FullSpecialize}(sys, ...)`; ModelingToolkit ignores a
+`specialize` keyword argument). ModelingToolkit's default level is
+`SciMLBase.AutoDespecialize`, which trades specialization for compile latency by routing
+generated code through type-erased wrappers. Today DiffEqGPU rebuilds the initialization
+functions fully specialized on the host regardless of the level, so both levels currently
+produce the same kernel and the same results. `FullSpecialize` is the level under which
+ModelingToolkit is planned to emit device-compatible initialization maps directly (see
+[ModelingToolkit.jl#5043](https://github.com/SciML/ModelingToolkit.jl/issues/5043)), and
+DiffEqGPU is expected to require it for kernel initialization once that lands, so new
+code should adopt it now.
 
 The current initialization path has the following restrictions:
 


### PR DESCRIPTION
## Summary

Documents the recommendation to construct ModelingToolkit problems for `EnsembleGPUKernel` initialization with `SciMLBase.FullSpecialize`, passed as the problem type parameter (`ODEProblem{iip, SciMLBase.FullSpecialize}(sys, ...)`), and updates the pendulum example accordingly. Adds a short "Specialization level" section to the ModelingToolkit tutorial stating:

- the type-parameter form is required (ModelingToolkit silently ignores a `specialize` keyword — verified: `ODEProblem(sys, ...; specialize = FullSpecialize)` still yields `AutoDespecialize`),
- ModelingToolkit's default is `AutoDespecialize`,
- today DiffEqGPU rebuilds initialization functions fully specialized on the host regardless of the level, so both levels produce identical kernels and results,
- `FullSpecialize` is the level under which ModelingToolkit is planned to emit device-compatible initialization maps directly (https://github.com/SciML/ModelingToolkit.jl/issues/5043), and DiffEqGPU is expected to require it for kernel initialization once that lands.

Docs only.

## Verification

- `ODEProblem{true, FullSpecialize}` and `ODEProblem{false, FullSpecialize}` on the tutorial's pendulum model, run through `EnsembleGPUKernel(JLBackend())` with `GPURodas5P`: `make_prob_compatible` isbits, `u0 = [0.99, 0.1411, 0.0, 0.0, 9.7119]`, `px^2 + py^2 = 1.0` — identical to the `AutoDespecialize` default. A torn initialization model with a computed state map also solves correctly (`u0 = [1.0, 3.0]`) under `FullSpecialize`.
- Observed: with either level, the initialization problem's own specialization is `AutoSpecialize` (ModelingToolkit's `initialization_specialization` mapping) — noted on the MTK issue; it is why the recommendation is forward-looking rather than a present-day behavior change.
- Local docs build: the edited page builds with no errors; the build as a whole fails only on CUDA `@example` blocks in untouched pages (`getting_started.md`, `gpu_ensemble_basic.md`, …) that cannot execute on this machine's GTX 1050 Ti (`code 801`). Documentation CI is the arbiter for those.
- Runic (docs code blocks) and typos: clean.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> **Note on Documentation CI:** `.github/workflows/GPU.yml` gates the `Documentation` job with `if: github.event_name == 'push' || !github.event.pull_request.draft`, so it shows as *skipping* while this PR is a draft and only runs once the PR is marked ready for review (or after merge — which is how #511's `missing_docs` failure escaped to master). Local validation of the edited page is in the Verification section; the full local build cannot go green on this machine (Pascal `code 801` on CUDA example pages).
