### PR TITLE
Suggest `mtkcompile(sys; homotopy = false)` when GPU initialization hits homotopy blocks

### DIFF
--- a/docs/src/tutorials/modelingtoolkit.md
+++ b/docs/src/tutorials/modelingtoolkit.md
@@ -184,7 +184,36 @@ The current initialization path has the following restrictions:
   - Ordinary nonlinear and linear SCC initialization blocks are supported, including
     all-linear SCC problems that carry no initial state: missing linear-block states are
     seeded with zeros, which the exact one-step linear solve does not depend on. SCC
-    initialization containing Modelica homotopy blocks is not supported.
+    initialization containing Modelica homotopy blocks is not supported; compile the
+    system with `homotopy = false` to remove them (see
+    [Systems using `homotopy`](@ref homotopy_gpu)).
 
 Structured `MTKParameters` storage is converted recursively to static storage, so this
 path does not require `split = false`.
+
+### [Systems using `homotopy`](@id homotopy_gpu)
+
+A system whose initialization carries Modelica `homotopy(actual, simplified)` operators
+builds a `HomotopyProblem`, which is solved by continuation. Continuation is a host-side
+sweep over a solver, so it has no device-compatible lowering and `EnsembleGPUKernel`
+rejects it:
+
+```
+ArgumentError: SCC nonlinear initialization problems containing homotopy blocks are not
+supported by EnsembleGPUKernel.
+```
+
+Pass `homotopy = false` to `mtkcompile` to compile the system without them:
+
+```julia
+pendulum = mtkcompile(pendulum; homotopy = false)
+```
+
+Every `homotopy(actual, simplified)` node is replaced by `actual` before compilation, so
+the compiled system contains no homotopy nodes, initialization builds a plain nonlinear
+problem, and the result lowers to the kernel like any other system. This is exact rather
+than an approximation: `actual` is what the operator evaluates to numerically anyway, per
+the Modelica specification. What is given up is only the `simplified` starting heuristic —
+the continuation's easier warm start — so a system that relied on it to converge from a
+cold start may need better guesses instead.
+

--- a/ext/ModelingToolkitBaseExt.jl
+++ b/ext/ModelingToolkitBaseExt.jl
@@ -37,7 +37,7 @@ function DiffEqGPU.lower_initialization_problem(prob::SciMLBase.SCCNonlinearProb
     )
     any(p -> nameof(typeof(p)) === :HomotopyProblem, prob.probs) && throw(
         ArgumentError(
-            "SCC nonlinear initialization problems containing homotopy blocks are not supported by EnsembleGPUKernel."
+            "SCC nonlinear initialization problems containing homotopy blocks are not supported by EnsembleGPUKernel. Recompile the system with `mtkcompile(sys; homotopy = false)` to replace every `homotopy(actual, simplified)` node by `actual`, which builds an equivalent initialization without homotopy blocks."
         )
     )
 


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

> ## ⚠️ BLOCKED: depends on an unmerged, unreleased ModelingToolkit feature
>
> The option this PR recommends, `mtkcompile(sys; homotopy = false)`, **does not exist in any released ModelingToolkit**. It is added by [SciML/ModelingToolkit.jl#5044](https://github.com/SciML/ModelingToolkit.jl/pull/5044), which is still open. On MTKBase 1.68.2 (current master) the keyword is unknown and following this advice errors.
>
> **Do not merge until #5044 is merged and released**, and when it is, raise `ModelingToolkitBase` in `[compat]` from `"1"` to the release that carries it. I could not pin that bound because the release does not exist yet.

## What changed and why

`EnsembleGPUKernel` rejects SCC initialization containing Modelica homotopy blocks — continuation is a host-side sweep over a solver, so there is no device lowering. Both the error and the tutorial stated the restriction without telling the user what to do instead:

```
ArgumentError: SCC nonlinear initialization problems containing homotopy blocks are not
supported by EnsembleGPUKernel.
```

`mtkcompile(sys; homotopy = false)` replaces every `homotopy(actual, simplified)` node by `actual` before compilation. That is exact rather than an approximation — `actual` is what the operator evaluates to numerically anyway, per the Modelica specification — so the compiled system contains no homotopy nodes, initialization builds a plain nonlinear problem, and it lowers to the kernel like any other system. What is given up is only the `simplified` starting heuristic, so a system that relied on it to converge from a cold start may need better guesses.

Two changes:

- `ext/ModelingToolkitBaseExt.jl` — the error message now names the option and says what it does. This is the surface users actually hit; a string change to an existing `ArgumentError`, no behavior change.
- `docs/src/tutorials/modelingtoolkit.md` — the restriction bullet links to a new `### Systems using `homotopy`` section under [DAE initialization](https://docs.sciml.ai/DiffEqGPU/stable/tutorials/modelingtoolkit/#dae_initialization) covering the error, the fix, and the tradeoff.

## Verification

Honest summary: **this is essentially unverified, at the user's instruction to push without waiting for local validation.**

What was run:

- `typos` — clean on both files.
- `runic --check` (v1.10.0) — clean on `ext/ModelingToolkitBaseExt.jl`.

What was **not** run, and should be before this leaves draft:

- **The new error message was never triggered at runtime.** I had a fixture ready (the `a -> b -> c` homotopy chain from MTK's `test/homotopy_initialization_scc.jl`, which produces an `SCCNonlinearProblem` with exactly one `HomotopyProblem` block) and an environment building to call `DiffEqGPU.lower_initialization_problem` on it, but the run was cut short. The change is a string literal inside an existing guard, so the risk is low, but "low risk" is not "verified".
- **No test was added.** There is currently no test anywhere in `test/` touching the homotopy guard (`grep -rn homotopy test/` is empty), so this PR leaves that gap exactly as it found it. A test asserting the error message names the option would make the suggestion a real contract, and I would add it before merge.
- **The docs build was not run.** The new `@id homotopy_gpu` anchor and the `@ref` pointing at it from the restriction bullet are unchecked; a typo in either is a Documenter `:cross_references` error. This is worth a reviewer's attention because it is the same class of bug this PR's sibling ([ModelingToolkit#5048](https://github.com/SciML/ModelingToolkit.jl/pull/5048)) exists to fix.
- **The recommended workflow was never executed end to end** — no system was compiled with `homotopy = false` and run through `EnsembleGPUKernel`, because that requires #5044. Nobody has demonstrated that the resulting problem actually lowers to the kernel; that is the central claim of this PR and it rests on reading #5044, not on running it.
- No GPU/CUDA jobs (no local GPU).

## For a reviewer to push back on

- Whether the error message should carry the suggestion at all while the option is unreleased. Naming a keyword that errors on the user's installed MTK is arguably worse than the current bare restriction. An alternative is docs-only until #5044 ships.
- The claim that stripping `homotopy` is "exact" is the operator's numeric semantics (`homotopy(a, s) = a`), but it does change convergence behavior. The wording tries to be careful about that distinction; check that it is careful enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])
https://claude.ai/code/session_01Aief3rKoTbHGqMPJZ7t2Jk
