### PR TITLE
Split GPU docs out of the CUDA Tests workflow

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,35 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
+
+jobs:
+  gpu-docs:
+    name: "Documentation"
+    runs-on: [self-hosted, gpu-v100]
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1"
+      - run: |
+          julia --project=docs -e '
+            println("--- Instantiating project")
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()
+            println("+++ Building documentation")
+            include("docs/make.jl")'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          DATADEPS_ALWAYS_ACCEPT: true

--- a/.github/workflows/GPU.yml
+++ b/.github/workflows/GPU.yml
@@ -1,14 +1,17 @@
-name: "CUDA Tests & Docs"
+name: "CUDA Tests"
 
 on:
   pull_request:
     branches:
       - master
       - 'release-'
+    paths-ignore:
+      - 'docs/**'
   push:
     branches:
       - master
-    tags: '*'
+    paths-ignore:
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -44,26 +47,3 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-
-  gpu-docs:
-    name: "Documentation"
-    runs-on: [self-hosted, gpu-v100]
-    timeout-minutes: 360
-    if: github.event_name == 'push' || !github.event.pull_request.draft
-    steps:
-      - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: "1"
-      - run: |
-          julia --project=docs -e '
-            println("--- Instantiating project")
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()
-            println("+++ Building documentation")
-            include("docs/make.jl")'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-          DATADEPS_ALWAYS_ACCEPT: true


### PR DESCRIPTION
> **Note:** this PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

`GPU.yml` (`CUDA Tests & Docs`) ran two jobs. The `Documentation` job had

```yaml
if: github.event_name == 'push' || !github.event.pull_request.draft
```

SciML agent PRs are opened as drafts, so that check **always showed skipped** on the PRs we look at. It was not a second docs build: it was the only Documenter job. There is no `Documentation.yml` on master today; the old GitHub docs workflow was removed in 2022 when docs moved to Buildkite, then Buildkite docs moved into this GPU workflow in March 2026.

This PR:

- Leaves CUDA tests in `GPU.yml` (renamed `CUDA Tests`, still `gpu-t4`).
- Moves the `gpu-v100` Documenter job to `.github/workflows/Documentation.yml` and drops the draft skip so docs actually run on PRs (and still deploy from master/tags).
- Restores `paths-ignore: docs/**` on CUDA tests so a docs-only PR no longer queues a 1h CUDA job while skipping the docs build.

## Verification

Commands run locally:

```
python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/GPU.yml")); yaml.safe_load(open(".github/workflows/Documentation.yml"))'
typos .github/workflows/GPU.yml .github/workflows/Documentation.yml
actionlint .github/workflows/GPU.yml .github/workflows/Documentation.yml
```

YAML loads. `typos` is clean. `actionlint` only reports the existing custom self-hosted labels (`gpu-t4`, `gpu-v100`), same as master.

No Julia tests: this is GitHub Actions YAML only. There is no package behavior to fail-before/pass-after.

What this PR's own CI should show, if the split is correct:

- A **Documentation** check that *runs* (not skipped), even while this PR is a draft.
- **CUDA Tests** still queued (workflow files are not under `docs/**`).
- No leftover `CUDA Tests & Docs` workflow name.

## What I did not verify

- The docs job on `gpu-v100` (needs the self-hosted runner; will be this PR's Documentation check).
- CUDA tests on `gpu-t4`.
- Buildkite AMDGPU/oneAPI/Metal.
- GitHub Pages deploy from a master push.

## For a reviewer to push back on

Dropping the draft skip means every PR, including drafts, occupies `gpu-v100` for the docs build (~20–30 min when it works). That was the original reason for the skip. The skip made the check useless on SciML PRs; running docs on PRs is the other way to stop it looking like a phantom job. If GPU queue time matters more, the `Documentation.yml` `on.pull_request` trigger can be removed so docs only build on master/tags.

GPU.yml concurrency (`github.ref != 'refs/tags/v*'` is a literal comparison and cancels master runs) is **not** touched here; that is https://github.com/SciML/DiffEqGPU.jl/pull/520.

---
🤖 Generated with Grok (harness: Grok 1.0.13, model: grok-4.6)
Agent-Session: 01a0528a-6142-7901-80ce-02d48776c462 (local Grok CLI session id; no shareable conversation URL)