### PR TITLE
Fix fixed-step final state after overshoot

### DIFF
--- a/src/ensemblegpukernel/kernels.jl
+++ b/src/ensemblegpukernel/kernels.jl
@@ -50,15 +50,14 @@
             saved_in_cb = step!(integ, ts, us)
             !saved_in_cb && savevalues!(integ, ts, us)
         end
+        if saveat === nothing && !save_everystep
+            @inbounds us[2] = integ.u
+            @inbounds ts[2] = integ.t
+        end
         if integ.t > tspan[2] && saveat === nothing
             ## Interpolate to tf
             @inbounds us[end] = integ(tspan[2])
             @inbounds ts[end] = tspan[2]
-        end
-
-        if saveat === nothing && !save_everystep
-            @inbounds us[2] = integ.u
-            @inbounds ts[2] = integ.t
         end
     else
         # Initialization failed — store initial values and bail out

--- a/test/gpu_kernel_de/gpu_ode_regression.jl
+++ b/test/gpu_kernel_de/gpu_ode_regression.jl
@@ -148,5 +148,8 @@ end
     )
 
     @test overshoot_sol.u[1].t == Float32[0, 1]
-    @test overshoot_sol.u[1].u[end] == SVector(1.0f0)
+    # OpenCL reassociates the endpoint interpolation by up to two Float32 ulps.
+    @test isapprox(
+        overshoot_sol.u[1].u[end], SVector(1.0f0); atol = 2eps(Float32), rtol = 0
+    )
 end

--- a/test/gpu_kernel_de/gpu_ode_regression.jl
+++ b/test/gpu_kernel_de/gpu_ode_regression.jl
@@ -137,3 +137,16 @@ for alg in algs
         adaptive = true, dt = 0.1f-1, abstol = 1.0f-7, reltol = 1.0f-7
     )
 end
+
+@testset "Fixed-step final state after overshoot" begin
+    unit_rate(u, p, t) = SVector(1.0f0)
+    overshoot_prob = ODEProblem{false}(unit_rate, SVector(0.0f0), (0.0f0, 1.0f0))
+    overshoot_ensemble = EnsembleProblem(overshoot_prob; safetycopy = false)
+    overshoot_sol = solve(
+        overshoot_ensemble, GPUTsit5(), EnsembleGPUKernel(backend);
+        trajectories = 2, adaptive = false, dt = 0.3f0, save_everystep = false
+    )
+
+    @test overshoot_sol.u[1].t == Float32[0, 1]
+    @test overshoot_sol.u[1].u[end] == SVector(1.0f0)
+end


### PR DESCRIPTION
## What changed

Fixed fixed-step `EnsembleGPUKernel` solves with `save_everystep = false` so an integrator step that overshoots the final time retains the interpolated state at `tspan[2]`. Previously the final time was interpolated correctly and then overwritten with the overshot integrator time and state.

Added a regression using `dt = 0.3f0` on `(0.0f0, 1.0f0)` so the final step necessarily overshoots.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before, with the source hunk reverted while retaining the test:

```text
GROUP=CPU JULIA_NUM_THREADS=4 julia +1.10.12 --project=.validation/test-env -e 'using Test; include("test/gpu_kernel_de/gpu_ode_regression.jl")'

Evaluated: Float32[0.0, 1.2] == Float32[0.0, 1.0]
Evaluated: Float32[1.2] == Float32[1.0]
Fixed-step final state after overshoot | 2 failed
```

Passing after:

```text
GROUP=CPU JULIA_NUM_THREADS=4 julia +1.10.12 --project=.validation/test-env -e 'using Test; include("test/gpu_kernel_de/gpu_ode_regression.jl")'

Test Summary:                          | Pass  Total  Time
Fixed-step final state after overshoot |    2      2  2.0s
```

The official CPU and QA groups also passed:

```text
GROUP=CPU julia +1.10.12 --project=.validation/test-env -e 'using Pkg; Pkg.test("DiffEqGPU")'
Testing DiffEqGPU tests passed

GROUP=QA julia +1.10.12 --project=.validation/test-env -e 'using Pkg; Pkg.test("DiffEqGPU")'
QA  | 25 passed
JET | 75 passed
Testing DiffEqGPU tests passed
```

Formatting, spelling, and whitespace checks passed:

```text
julia --startup-file=no -e 'using Runic; exit(Runic.main(ARGS))' -- --check src/ensemblegpukernel/kernels.jl test/gpu_kernel_de/gpu_ode_regression.jl
typos src/ensemblegpukernel/kernels.jl test/gpu_kernel_de/gpu_ode_regression.jl
git diff --check upstream/master...HEAD
```

## Not verified

No GPU is available locally, so this was exercised with the KernelAbstractions CPU backend. The docs build was attempted, but its CUDA-backed examples fail with `CUDA driver not functional` on this host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
