### PR TITLE
Release DiffEqGPU 3.20.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqGPU"
 uuid = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 authors = ["Chris Rackauckas", "SciML"]
-version = "3.20.1"
+version = "3.20.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Bumps `DiffEqGPU` 3.20.1 -> 3.20.2 (patch).

Source files changed since 3.20.1:
- `src/ensemblegpukernel/kernels.jl`

Commits:
- Recommend FullSpecialize for ModelingToolkit initialization on GPU kernels (#522)
- Split GPU docs out of the CUDA Tests workflow (#525)
- Fix fixed-step final state after overshoot (#526)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
