### PR TITLE
Add 32-bit CPU CI lane via test_groups.toml

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,6 +1,12 @@
 [CPU]
 versions = ["lts", "1", "pre"]
 
+["CPU 32-bit"]
+group = "CPU"
+versions = ["1"]
+os = ["ubuntu-latest"]
+arch = "x86"
+
 [JLArrays]
 versions = ["lts", "1", "pre"]
 


### PR DESCRIPTION

## Summary
- Add a `["CPU 32-bit"]` matrix-only alias (`group = "CPU"`, `arch = "x86"`, Linux only) so this package exercises 32-bit Julia via SciML/.github `@v1`.
- No `[Core]` group in this matrix; alias targets the primary `CPU` lane.

## Test plan
- [ ] CI shows a job with `, x86)` for this group
- [ ] Job green, or failure is a real Int32/WordSize bug to fix
