### PR TITLE
Fuse fixed-step GPUTsit5 arithmetic and document controller accuracy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Adaptive controller conventions
+
+Preserve the existing `GPUTsit5` PI-controller behavior. Alternative controllers must be explicit opt-in variants, with documentation explaining their step-size stability and accuracy tradeoffs. Do not change the default based on equal-tolerance timing alone: use work–precision comparisons at matched achieved error, include rejected steps, and test beyond simple nonstiff problems such as Lorenz.

--- a/benchmark/tsit5.jl
+++ b/benchmark/tsit5.jl
@@ -1,0 +1,40 @@
+using DiffEqGPU, SciMLBase, StaticArrays, KernelAbstractions, Adapt, BenchmarkTools
+
+const backend = if get(ENV, "GROUP", "CPU") == "CUDA"
+    using CUDA
+    CUDA.CUDABackend()
+else
+    CPU()
+end
+
+function lorenz(u::SVector{3, T}, p, t) where {T}
+    return SVector(
+        T(10) * (u[2] - u[1]),
+        p[1] * u[1] - u[2] - u[1] * u[3],
+        u[1] * u[2] - T(8 / 3) * u[3]
+    )
+end
+
+function benchmark_tsit5(::Type{T}, n, adaptive) where {T}
+    prob = ODEProblem{false}(
+        lorenz, SVector{3, T}(1, 0, 0), (zero(T), one(T)), SVector{1, T}(21)
+    )
+    probs = [remake(prob; p = SVector{1, T}(rho)) for rho in range(0, 21; length = n)]
+    gpu_probs = adapt(backend, adapt.((backend,), probs))
+    solver = adaptive ? DiffEqGPU.vectorized_asolve : DiffEqGPU.vectorized_solve
+    function solve_once()
+        result = solver(
+            gpu_probs, prob, GPUTsit5(); dt = T(1.0e-3),
+            reltol = T(1.0e-6), abstol = T(1.0e-9), save_everystep = false
+        )
+        KernelAbstractions.synchronize(backend)
+        return result
+    end
+    ts, us = solve_once()
+    trial = @benchmark $solve_once() samples = 20 evals = 1
+    return (; T, n, adaptive, minimum_ms = minimum(trial).time / 1.0e6, final = Array(us)[end, end])
+end
+
+for T in (Float32, Float64), adaptive in (false, true)
+    @show benchmark_tsit5(T, parse(Int, get(ENV, "TRAJECTORIES", "4096")), adaptive)
+end

--- a/docs/src/manual/ensemblegpukernel.md
+++ b/docs/src/manual/ensemblegpukernel.md
@@ -20,3 +20,20 @@ GPURodas5P
 GPUKvaerno3
 GPUKvaerno5
 ```
+
+### Adaptive controllers and benchmark comparisons
+
+The adaptive `GPUTsit5` implementation uses a PI controller. Keep this controller
+for general use. A pure I controller responds only to the current error estimate
+and generally provides less stable step-size control, so it is not recommended as
+a general replacement for the PI controller.
+
+On simple nonstiff benchmarks such as Lorenz, an I-controlled Tsit5 implementation
+can appear faster at the same `abstol` and `reltol`, partly because it delivers lower
+achieved accuracy. Equal tolerances do not imply equal accuracy. Compare execution
+time at matched achieved error, and account for rejected steps, before concluding
+that one controller is more efficient.
+
+Changing the controller preserves the Tsit5 Runge–Kutta tableau but changes step
+selection and tolerance behavior. Any I-controlled variant should remain an
+explicit alternative, preserving the existing `GPUTsit5` behavior.

--- a/src/ensemblegpukernel/perform_step/gpu_tsit5_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_tsit5_perform_step.jl
@@ -65,7 +65,7 @@ end
 
 #############################Adaptive Version#####################################
 
-@muladd @inline function step!(integ::GPUAT5I{false, S, T}, ts, us) where {S, T}
+@muladd function step!(integ::GPUAT5I{false, S, T}, ts, us) where {S, T}
     beta1, beta2, qmax, qmin, gamma, qoldinit,
         _ = build_adaptive_controller_cache(
         integ.alg,

--- a/src/ensemblegpukernel/perform_step/gpu_tsit5_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_tsit5_perform_step.jl
@@ -1,4 +1,4 @@
-@inline function step!(integ::GPUT5I{false, S, T}, ts, us) where {T, S}
+@muladd @inline function step!(integ::GPUT5I{false, S, T}, ts, us) where {T, S}
     c1, c2, c3, c4, c5, c6 = integ.cs
     dt = integ.dt
     t = integ.t
@@ -65,7 +65,7 @@ end
 
 #############################Adaptive Version#####################################
 
-@inline function step!(integ::GPUAT5I{false, S, T}, ts, us) where {S, T}
+@muladd @inline function step!(integ::GPUAT5I{false, S, T}, ts, us) where {S, T}
     beta1, beta2, qmax, qmin, gamma, qoldinit,
         _ = build_adaptive_controller_cache(
         integ.alg,

--- a/src/ensemblegpukernel/perform_step/gpu_tsit5_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_tsit5_perform_step.jl
@@ -65,7 +65,7 @@ end
 
 #############################Adaptive Version#####################################
 
-@muladd function step!(integ::GPUAT5I{false, S, T}, ts, us) where {S, T}
+@inline function step!(integ::GPUAT5I{false, S, T}, ts, us) where {S, T}
     beta1, beta2, qmax, qmin, gamma, qoldinit,
         _ = build_adaptive_controller_cache(
         integ.alg,

--- a/test/gpu_kernel_de/tsit5_accuracy.jl
+++ b/test/gpu_kernel_de/tsit5_accuracy.jl
@@ -17,3 +17,18 @@ include("../utils.jl")
         @test u ≈ SVector(exp(T(0.5) * t), sin(t)) rtol = 2.0e-6 atol = 2.0e-7
     end
 end
+
+@testset "Tsit5 short endpoint ($T, reltol=$tol)" for
+    T in (GROUP in ("CPU", "CUDA", "AMDGPU") ? (Float32, Float64) : (Float32,)),
+        tol in (1.0e-3, 1.0e-4)
+    rhs(u, p, t) = SVector(-u[1], -100 * u[2])
+    prob = ODEProblem{false}(rhs, SVector(one(T), one(T)), (zero(T), T(0.1)))
+    sol = solve(
+        EnsembleProblem(prob), GPUTsit5(), EnsembleGPUKernel(backend, 0.0);
+        trajectories = 2, adaptive = true, dt = T(0.1),
+        abstol = T(tol / 1000), reltol = T(tol), save_everystep = false
+    )
+    exact = SVector(exp(-T(0.1)), exp(-T(10)))
+    @test all(s -> s.t[end] == T(0.1), sol.u)
+    @test all(s -> isapprox(s.u[end], exact; atol = T(2.0e-6), rtol = T(2.0e-6)), sol.u)
+end

--- a/test/gpu_kernel_de/tsit5_accuracy.jl
+++ b/test/gpu_kernel_de/tsit5_accuracy.jl
@@ -1,0 +1,19 @@
+using DiffEqGPU, SciMLBase, StaticArrays, Test
+include("../utils.jl")
+
+@testset "Tsit5 nonautonomous accuracy ($T, adaptive=$adaptive)" for
+    T in (GROUP in ("CPU", "CUDA", "AMDGPU") ? (Float32, Float64) : (Float32,)),
+        adaptive in (false, true)
+    rhs(u, p, t) = SVector(p[1] * u[1], cos(t))
+    prob = ODEProblem{false}(
+        rhs, SVector(T(1), T(0)), (T(0), T(1)), SVector(T(0.5))
+    )
+    sol = solve(
+        EnsembleProblem(prob), GPUTsit5(), EnsembleGPUKernel(backend, 0.0);
+        trajectories = 3, adaptive, dt = T(0.01),
+        abstol = T(1.0e-7), reltol = T(1.0e-6), saveat = T[0, 0.25, 0.5, 1]
+    )
+    for trajectory in sol.u, (t, u) in zip(trajectory.t, trajectory.u)
+        @test u ≈ SVector(exp(T(0.5) * t), sin(t)) rtol = 2.0e-6 atol = 2.0e-7
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,9 @@ end
 @time @safetestset "GPU Kernelized Non Stiff ODE Regression" begin
     include("gpu_kernel_de/gpu_ode_regression.jl")
 end
+@time @safetestset "Tsit5 accuracy" begin
+    include("gpu_kernel_de/tsit5_accuracy.jl")
+end
 @time @safetestset "GPU Kernelized Non Stiff ODE DiscreteCallback" begin
     include("gpu_kernel_de/gpu_ode_discrete_callbacks.jl")
 end


### PR DESCRIPTION
Tsit5 stage arithmetic currently emits separate multiply/add operations. Apply the existing `@muladd` dependency to the fixed-step stepper, add nonautonomous accuracy coverage in both precisions, and provide a synchronized Lorenz benchmark that can run on CPU or CUDA.

Document the recommendation to retain the existing PI controller for general use: I-controlled variants can have less stable step-size behavior and can look faster at equal tolerances partly because of lower achieved accuracy. Preserve the default algorithm and require matched-error comparisons; record that convention in `AGENTS.md`. No controller or algorithm selector is changed.

This addresses one concrete optimization opportunity identified while investigating https://arxiv.org/abs/2609.02876. It does **not** establish or close the paper’s reported 2.8× CUDA gap. Its published notebook uses equal tolerances with different achieved errors (GRADSOLVE 3.17e-7 versus DiffEqGPU 1.00e-7 at 524,288 trajectories); its controller also differs. Source: https://github.com/ECLIPSE-AI4Science/gradsolve/blob/main/benchmarks/forward_vs_diffeqgpu.ipynb.

Before/after CPU measurements in the same Julia process, reloading the original and modified steppers, 4,096 Lorenz trajectories, tspan=(0,1), dt=0.001, reltol=1e-6, abstol=1e-9, minimum of ten synchronized runs:

| Precision / stepping | Original ms | FMA ms |
|---|---:|---:|
| Float32 fixed | 220.127 | 194.429 |
| Float64 fixed | 220.152 | 193.956 |

The fixed-step CPU reduction is about 12%. These are not GPU measurements. Also ran `julia +1.12 --project=scratch/env DiffEqGPU.jl/benchmark/tsit5.jl` successfully. The original analytic accuracy checks pass on both versions. The adaptive implementation is byte-for-byte identical to the base revision; its controller, arithmetic, and inline annotation are preserved.

The new short-endpoint regression covers two trajectories of `u′=(-u₁,-100u₂)`, Float32/Float64, `tspan=(0,0.1)`, and initial `dt=0.1`. An adaptive FMA candidate with forced inlining timed out on LTS; removing the inline hint then broke OpenCL adaptive output and the tight Float64 Enzyme gradient check. These failures justify limiting this PR to fixed-step FMA. No assertion was loosened to retain the adaptive optimization.

```text
# Same short-endpoint regression with adaptive FMA and forced inlining:
timeout 180 julia +lts --project=scratch/perf-lts-env scratch/perf_endpoint_regression.jl
exit 124

# After restoring the original adaptive implementation:
julia +lts --project=scratch/perf-lts-env scratch/perf_endpoint_regression.jl
Float32 reltol=1e-3: 2/2; Float32 reltol=1e-4: 2/2
Float64 reltol=1e-3: 2/2; Float64 reltol=1e-4: 2/2

# OpenCL Lorenz adaptive solve with the uninlined FMA candidate:
julia +lts --project=scratch/fma-opencl-lts-env scratch/perf-opencl-adaptive-probe.jl
ERROR: Batch solve failed; output times [0.0f0, 0.0f0]

# Same solve after restoring the original adaptive implementation:
exit 0
```

Final local validation after retaining the original adaptive implementation:

```text
GROUP=CPU julia +lts --project=scratch/perf-lts-env -e 'using Pkg; Pkg.test("DiffEqGPU")'
Tsit5 accuracy | 56 56 12.6s
Testing DiffEqGPU tests passed
GROUP=QA julia +1.12 --project=DiffEqGPU.jl -e 'using Pkg; Pkg.test()'
Quality Assurance | 27 27 2m17.3s
JET static analysis | 75 75 21.8s
Testing DiffEqGPU tests passed
```

The combined checkout with the Enzyme and optional-controller changes passed all 12 CPU Enzyme assertions (both selectors, precisions, fixed/adaptive exponentials, and Lorenz variational references). The uninlined adaptive candidate failed the Float64 exponential gradient bound; restoring the original adaptive code passes it without changing the tolerance. The full OpenCL LTS suite also passed: `GROUP=OpenCL julia +lts --project=scratch/fma-opencl-lts-env -e 'using Pkg; Pkg.test("DiffEqGPU")'` ended with `Testing DiffEqGPU tests passed`. The exact previously failing adaptive solve also exits 0 locally.

Runic, typos, and `git diff --check` exited 0.

Not verified locally: CUDA/GPU execution, GPU throughput, downstream packages, and allowed-to-fail Julia prerelease jobs. No NVIDIA GPU is present on this host (`CUDA.functional() == false`). No public API changed. The fixed-step optimization adds no dependency; MuladdMacro is already a runtime dependency. After adding the controller guidance, ran `julia +1.12 --project=docs docs/make.jl`; it failed on existing CUDA examples because this host has no functional CUDA driver, and on a GitHub link check returning HTTP 429. The changed page contains prose and existing API entries, with no new executable example. The earlier performance commit passed the GPU-backed documentation and CUDA test jobs in CI. FMA can change floating-point rounding; the accuracy tests and existing callback/interpolation tests passed without loosening assertions.

The matched-error controller experiment and data are recorded at https://github.com/ChrisRackauckas/InternalJunk/pull/99. The independent 32-bit CI dependency failures are tracked with reproducers at https://github.com/SciML/DiffEqGPU.jl/issues/531.

Ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session ID: 01a07fcc-1c4f-7ee3-9a1e-51eaab7df293).
