### PR TITLE
Add opt-in GPUTsit5IController while preserving PI behavior

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqGPU"
 uuid = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 authors = ["Chris Rackauckas", "SciML"]
-version = "3.20.2"
+version = "3.21.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/manual/ensemblegpukernel.md
+++ b/docs/src/manual/ensemblegpukernel.md
@@ -10,6 +10,7 @@ EnsembleGPUKernel
 
 ```@docs
 GPUTsit5
+GPUTsit5IController
 GPUVern7
 GPUVern9
 GPUEM
@@ -37,3 +38,4 @@ that one controller is more efficient.
 Changing the controller preserves the Tsit5 Runge–Kutta tableau but changes step
 selection and tolerance behavior. Any I-controlled variant should remain an
 explicit alternative, preserving the existing `GPUTsit5` behavior.
+`GPUTsit5IController()` provides this opt-in I-controller variant.

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -241,7 +241,7 @@ export BrownFullBasicInit, CheckInit
 
 export EnsembleCPUArray, EnsembleGPUArray, EnsembleGPUKernel, LinSolveGPUSplitFactorize
 
-export GPUTsit5, GPUVern7, GPUVern9, GPUEM, GPUSIEA
+export GPUTsit5, GPUTsit5IController, GPUVern7, GPUVern9, GPUEM, GPUSIEA
 ## Stiff ODE solvers
 export GPURosenbrock23, GPURodas4, GPURodas5P, GPUKvaerno3, GPUKvaerno5
 

--- a/src/ensemblegpukernel/alg_utils.jl
+++ b/src/ensemblegpukernel/alg_utils.jl
@@ -3,6 +3,7 @@ function alg_order(alg::Union{GPUODEAlgorithm, GPUSDEAlgorithm})
 end
 
 alg_order(alg::GPUTsit5) = 5
+alg_order(alg::GPUTsit5IController) = 5
 alg_order(alg::GPUVern7) = 7
 alg_order(alg::GPUVern9) = 9
 alg_order(alg::GPURosenbrock23) = 2

--- a/src/ensemblegpukernel/gpukernel_algorithms.jl
+++ b/src/ensemblegpukernel/gpukernel_algorithms.jl
@@ -30,6 +30,25 @@ with the `EnsembleGPUKernel` restrictions.
 struct GPUTsit5 <: GPUODEAlgorithm end
 
 """
+    GPUTsit5IController()
+
+Fifth-order Tsitouras method with a current-error-only integral (I) step-size
+controller for `EnsembleGPUKernel`. The Runge-Kutta tableau, error estimate, and
+interpolation are the same as [`GPUTsit5`](@ref); fixed-step solves are identical.
+
+For adaptive solves, the next step is multiplied by
+`clamp(0.9 * E^(-1/5), 0.2, 5)`, where `E` is the scaled error norm. Zero error
+uses the maximum growth factor. The same rule applies after rejected steps.
+Use `EnsembleGPUKernel(backend, 0.0)`; CPU offloading is not supported.
+
+Generally prefer the PI-controlled [`GPUTsit5`](@ref), which has more stable
+step-size control. On simple nonstiff benchmarks such as Lorenz, an I controller
+can appear faster at identical tolerances partly because it achieves lower
+accuracy. Compare performance at matched achieved error.
+"""
+struct GPUTsit5IController <: GPUODEAlgorithm end
+
+"""
     GPUVern7()
 
 Seventh-order Verner Runge-Kutta method specialized for `EnsembleGPUKernel` ODE

--- a/src/ensemblegpukernel/integrators/integrator_utils.jl
+++ b/src/ensemblegpukernel/integrators/integrator_utils.jl
@@ -10,6 +10,10 @@ function build_adaptive_controller_cache(alg::A, ::Type{T}) where {A, T}
     return beta1, beta2, qmax, qmin, gamma, qoldinit, qold
 end
 
+function build_adaptive_controller_cache(::GPUTsit5IController, ::Type{T}) where {T}
+    return T(1 / 5), zero(T), T(5), T(1 / 5), T(9 / 10), T(1.0e-4), T(1.0e-4)
+end
+
 @inline function savevalues!(
         integrator::SciMLBase.AbstractODEIntegrator{
             AlgType,

--- a/src/ensemblegpukernel/integrators/nonstiff/types.jl
+++ b/src/ensemblegpukernel/integrators/nonstiff/types.jl
@@ -303,7 +303,7 @@ end
 # Initialization of Integrators
 #######################################################################################
 @inline function init(
-        alg::GPUTsit5, f::F, IIP::Bool, u0::S, t0::T, dt::T,
+        alg::Union{GPUTsit5, GPUTsit5IController}, f::F, IIP::Bool, u0::S, t0::T, dt::T,
         p::P, tstops::TS,
         callback::CB,
         save_everystep::Bool,
@@ -338,7 +338,7 @@ end
 end
 
 @inline function init(
-        alg::GPUTsit5, f::F, IIP::Bool, u0::S, t0::T, tf::T, dt::T,
+        alg::Union{GPUTsit5, GPUTsit5IController}, f::F, IIP::Bool, u0::S, t0::T, tf::T, dt::T,
         p::P,
         abstol::TOL, reltol::TOL,
         internalnorm::N, tstops::TS,

--- a/src/ensemblegpukernel/perform_step/gpu_tsit5_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_tsit5_perform_step.jl
@@ -122,7 +122,7 @@ end
         EEst = DiffEqBase.ODE_DEFAULT_NORM(tmp, t)
 
         if iszero(EEst)
-            q = inv(qmax)
+            q = integ.alg isa GPUTsit5IController ? zero(T) : inv(qmax)
         else
             q11 = EEst^beta1
             q = q11 / (qold^beta2)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -45,6 +45,10 @@ function SciMLBase.__solve(
         round(Int, trajectories * ensemblealg.cpu_offload) : 0
     gpu_trajectories = trajectories - cpu_trajectories
 
+    if alg isa GPUTsit5IController && cpu_trajectories != 0
+        throw(ArgumentError("GPUTsit5IController requires cpu_offload = 0."))
+    end
+
     num_batches = gpu_trajectories ÷ batch_size
     num_batches * batch_size != gpu_trajectories && (num_batches += 1)
 

--- a/test/gpu_kernel_de/tsit5_accuracy.jl
+++ b/test/gpu_kernel_de/tsit5_accuracy.jl
@@ -1,15 +1,16 @@
 using DiffEqGPU, SciMLBase, StaticArrays, Test
 include("../utils.jl")
 
-@testset "Tsit5 nonautonomous accuracy ($T, adaptive=$adaptive)" for
-    T in (GROUP in ("CPU", "CUDA", "AMDGPU") ? (Float32, Float64) : (Float32,)),
+@testset "Tsit5 nonautonomous accuracy ($alg, $T, adaptive=$adaptive)" for
+    alg in (GPUTsit5(), GPUTsit5IController()),
+        T in (GROUP in ("CPU", "CUDA", "AMDGPU") ? (Float32, Float64) : (Float32,)),
         adaptive in (false, true)
     rhs(u, p, t) = SVector(p[1] * u[1], cos(t))
     prob = ODEProblem{false}(
         rhs, SVector(T(1), T(0)), (T(0), T(1)), SVector(T(0.5))
     )
     sol = solve(
-        EnsembleProblem(prob), GPUTsit5(), EnsembleGPUKernel(backend, 0.0);
+        EnsembleProblem(prob), alg, EnsembleGPUKernel(backend, 0.0);
         trajectories = 3, adaptive, dt = T(0.01),
         abstol = T(1.0e-7), reltol = T(1.0e-6), saveat = T[0, 0.25, 0.5, 1]
     )

--- a/test/gpu_kernel_de/tsit5_accuracy.jl
+++ b/test/gpu_kernel_de/tsit5_accuracy.jl
@@ -19,13 +19,13 @@ include("../utils.jl")
     end
 end
 
-@testset "Tsit5 short endpoint ($T, reltol=$tol)" for
+@testset "Tsit5 short endpoint ($alg, $T, reltol=$tol)" for
     T in (GROUP in ("CPU", "CUDA", "AMDGPU") ? (Float32, Float64) : (Float32,)),
-        tol in (1.0e-3, 1.0e-4)
+        tol in (1.0e-3, 1.0e-4), alg in (GPUTsit5(), GPUTsit5IController())
     rhs(u, p, t) = SVector(-u[1], -100 * u[2])
     prob = ODEProblem{false}(rhs, SVector(one(T), one(T)), (zero(T), T(0.1)))
     sol = solve(
-        EnsembleProblem(prob), GPUTsit5(), EnsembleGPUKernel(backend, 0.0);
+        EnsembleProblem(prob), alg, EnsembleGPUKernel(backend, 0.0);
         trajectories = 2, adaptive = true, dt = T(0.1),
         abstol = T(tol / 1000), reltol = T(tol), save_everystep = false
     )

--- a/test/gpu_kernel_de/tsit5_i_controller.jl
+++ b/test/gpu_kernel_de/tsit5_i_controller.jl
@@ -9,7 +9,9 @@ end
 
 @testset "I-controller convergence beyond Lorenz ($T)" for T in
     (GROUP in ("CPU", "CUDA", "AMDGPU") ? (Float32, Float64) : (Float32,))
-    tolerances = T === Float64 ? (T(1.0e-4), T(1.0e-8)) : (T(1.0e-3), T(1.0e-5))
+    # The slow decay component reaches Float32 roundoff before the tighter tolerance.
+    # Keep the coarse solve above that floor so the error-ratio check measures convergence.
+    tolerances = T === Float64 ? (T(1.0e-4), T(1.0e-8)) : (T(1.0e-2), T(1.0e-5))
     cases = (
         ((u, p, t) -> SVector(10 * u[2], -10 * u[1]), SVector(one(T), zero(T)), T(10), SVector(cos(T(100)), -sin(T(100)))),
         ((u, p, t) -> SVector(-u[1], -100 * u[2]), SVector(one(T), one(T)), one(T), SVector(exp(-one(T)), exp(T(-100)))),

--- a/test/gpu_kernel_de/tsit5_i_controller.jl
+++ b/test/gpu_kernel_de/tsit5_i_controller.jl
@@ -1,0 +1,72 @@
+function controller_integrator(alg, rhs, ::Type{T}; qold = T(1.0e-4)) where {T}
+    integ = DiffEqGPU.init(
+        alg, rhs, false, SVector(one(T)), zero(T), T(10), T(0.5),
+        nothing, T(1.0e-10), T(1.0e-8), nothing, nothing, CallbackSet(), nothing
+    )
+    integ.qold = qold
+    return integ
+end
+
+@testset "I-controller convergence beyond Lorenz ($T)" for T in
+    (GROUP in ("CPU", "CUDA", "AMDGPU") ? (Float32, Float64) : (Float32,))
+    tolerances = T === Float64 ? (T(1.0e-4), T(1.0e-8)) : (T(1.0e-3), T(1.0e-5))
+    cases = (
+        ((u, p, t) -> SVector(10 * u[2], -10 * u[1]), SVector(one(T), zero(T)), T(10), SVector(cos(T(100)), -sin(T(100)))),
+        ((u, p, t) -> SVector(-u[1], -100 * u[2]), SVector(one(T), one(T)), one(T), SVector(exp(-one(T)), exp(T(-100)))),
+    )
+    for (rhs, u0, tf, exact) in cases
+        prob = ODEProblem{false}(rhs, u0, (zero(T), tf))
+        errors = map(tolerances) do tol
+            sol = solve(
+                EnsembleProblem(prob), GPUTsit5IController(), EnsembleGPUKernel(backend, 0.0);
+                trajectories = 2, adaptive = true, dt = T(0.1),
+                abstol = tol / T(1000), reltol = tol, save_everystep = false
+            )
+            maximum(abs.(sol.u[1].u[end] - exact))
+        end
+        @test errors[2] < errors[1] / 10
+        @test errors[2] < (T === Float64 ? 1.0e-5 : 1.0e-3)
+    end
+end
+
+@testset "Tsit5 controller step response ($T)" for T in (Float32, Float64)
+    for (alg, growth) in ((GPUTsit5(), T(9)), (GPUTsit5IController(), T(5)))
+        integ = controller_integrator(alg, (u, p, t) -> zero(u), T)
+        initial_dt = integ.dtnew
+        DiffEqGPU.step!(integ, nothing, nothing)
+        @test integ.dt == initial_dt
+        @test integ.dtnew ≈ growth * initial_dt
+    end
+
+    for alg in (GPUTsit5(), GPUTsit5IController())
+        first_history = controller_integrator(alg, (u, p, t) -> u, T; qold = T(0.01))
+        second_history = controller_integrator(alg, (u, p, t) -> u, T; qold = one(T))
+        DiffEqGPU.step!(first_history, nothing, nothing)
+        DiffEqGPU.step!(second_history, nothing, nothing)
+        @test first_history.dt < T(0.5)
+        @test first_history.u ≈ SVector(exp(first_history.t))
+        if alg isa GPUTsit5IController
+            @test first_history.dtnew == second_history.dtnew
+            @test T(0.2) <= first_history.dtnew / first_history.dt <= T(5)
+        else
+            @test first_history.dtnew != second_history.dtnew
+        end
+    end
+end
+
+@testset "Tsit5 fixed-step equivalence" begin
+    rhs(u, p, t) = SVector(10 * (u[2] - u[1]), u[1] * (28 - u[3]) - u[2], u[1] * u[2] - (8.0f0 / 3.0f0) * u[3])
+    prob = ODEProblem{false}(rhs, SVector(1.0f0, 0.0f0, 0.0f0), (0.0f0, 1.0f0))
+    ensemble = EnsembleProblem(prob)
+    results = map((GPUTsit5(), GPUTsit5IController())) do alg
+        solve(
+            ensemble, alg, EnsembleGPUKernel(backend, 0.0);
+            trajectories = 2, adaptive = false, dt = 0.01f0, saveat = Float32[0, 0.5, 1]
+        )
+    end
+    @test all(results[1].u[i].u == results[2].u[i].u for i in 1:2)
+    @test_throws ArgumentError solve(
+        ensemble, GPUTsit5IController(), EnsembleGPUKernel(backend, 0.5);
+        trajectories = 2, adaptive = true, dt = 0.01f0
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,7 @@ end
 end
 @time @safetestset "Tsit5 accuracy" begin
     include("gpu_kernel_de/tsit5_accuracy.jl")
+    include("gpu_kernel_de/tsit5_i_controller.jl")
 end
 @time @safetestset "GPU Kernelized Non Stiff ODE DiscreteCallback" begin
     include("gpu_kernel_de/gpu_ode_discrete_callbacks.jl")


### PR DESCRIPTION
Adds `GPUTsit5IController()` as an explicit alternative to `GPUTsit5()`. It keeps the Tsit5 tableau and interpolation, uses the current-error-only update `clamp(0.9 * E^(-1/5), 0.2, 5)`, and preserves the original PI controller. The public API addition bumps the package to 3.21.0.

Docs generally recommend the PI controller: I control has less stable step-size selection and can appear faster on Lorenz at equal tolerances because achieved accuracy differs. CPU offloading is rejected for this selector because the CPU fallback has no equivalent controller. Fixed-step solves are identical.

This is stacked on https://github.com/SciML/DiffEqGPU.jl/pull/529; until that lands, its performance commits also appear in this diff. Controller work-precision evidence: https://github.com/ChrisRackauckas/InternalJunk/pull/99.

Verification (Julia 1.12.7, CPU backend):

```text
GROUP=CPU julia +1.12 --project -e 'using Pkg; Pkg.test()'
Tsit5 accuracy | 128  128  30.2s
Testing DiffEqGPU tests passed

GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test()'
QA: 27/27; JET: 75/75
```

The 128 assertions cover both precisions and selectors, rejected steps, dependence on controller history, zero-error growth, fixed-step equality, and convergence on an oscillator and separated decay rates. Eight original PI one-step controller-state snapshots were byte-identical before/after (`cmp` exited 0). Runic, typos, and `git diff --check` exited 0.

The latest combined checkout with https://github.com/SciML/DiffEqGPU.jl/pull/532 passed all 12 Enzyme gradient assertions after restoring the original adaptive implementation: both controllers, Float32/Float64 fixed/adaptive exponentials, and Lorenz parameter gradients against independently integrated variational equations. This is a new optional feature, not a change to default solver behavior.

Local `julia +1.12 --project=docs docs/make.jl` reached the examples and failed on existing CUDA examples because this host has no NVIDIA GPU. No errors referenced the new documentation. GPU tests and GPU throughput were not verified locally; CPU evidence is not a GPU speed claim. No new dependency is added. Adaptive Tsit5 arithmetic and its original inline annotation are retained; the performance prerequisite now restricts FMA to the fixed-step kernel.

LTS validation: `GROUP=CPU julia +lts --project -e 'using Pkg; Pkg.test()'` completed with `Testing DiffEqGPU tests passed`; the Tsit5 accuracy group passed all 144 assertions (32.4s), including short endpoint solves for both selectors and precisions. The initial LTS CI convergence check compared Float32 errors near the rounding floor (8.94e-8 versus a 3.67e-8 ratio bound). The coarse sampling tolerance now keeps that solve above roundoff; the tenfold reduction assertion and absolute accuracy bounds remain unchanged. Native and generic local LTS builds also passed the original test, so this is a compiler-sensitive test-sampling correction, not evidence of a local solver failure.

Ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session ID: 01a07fcc-1c4f-7ee3-9a1e-51eaab7df293).
