### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "OrdinaryDiffEqTsit5,StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,39 @@
+using DiffEqGPU, BenchmarkTools
+using OrdinaryDiffEqTsit5, StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+function lorenz(du, u, p, t)
+    du[1] = p[1] * (u[2] - u[1])
+    du[2] = u[1] * (p[2] - u[3]) - u[2]
+    return du[3] = u[1] * u[2] - p[3] * u[3]
+end
+
+u0 = Float32[1.0; 0.0; 0.0]
+tspan = (0.0f0, 50.0f0)
+p = (10.0f0, 28.0f0, 8 / 3.0f0)
+prob = ODEProblem(lorenz, u0, tspan, p)
+pre_p = [rand(rng, Float32, 3) for i in 1:32]
+prob_func = (prob, ctx) -> remake(prob, p = pre_p[ctx.sim_id] .* p)
+monteprob = EnsembleProblem(prob; prob_func)
+
+# =============================================================================
+# Ensemble solving on the CPU-array backend
+# =============================================================================
+
+SUITE["ensemble"] = BenchmarkGroup()
+
+SUITE["ensemble"]["cpu_array_16"] = @benchmarkable solve(
+    $monteprob, Tsit5(), EnsembleCPUArray(); trajectories = 16, saveat = 1.0f0
+)
+SUITE["ensemble"]["cpu_array_32"] = @benchmarkable solve(
+    $monteprob, Tsit5(), EnsembleCPUArray(); trajectories = 32, saveat = 1.0f0
+)
+SUITE["ensemble"]["threads_16"] = @benchmarkable solve(
+    $monteprob, Tsit5(), EnsembleThreads(); trajectories = 16, saveat = 1.0f0
+)
+SUITE["ensemble"]["cpu_array_batch"] = @benchmarkable solve(
+    $monteprob, Tsit5(), EnsembleCPUArray(); trajectories = 32,
+    batch_size = 8, saveat = 1.0f0
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~40s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~40s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 Max)
Session: local transcript /home/crackauc/.local/share/devin/cli/summaries/history_ccb52064e6514b21.md