### PR TITLE
Fix adaptive last-step overshoot past tf

### DIFF
--- a/src/ensemblegpukernel/perform_step/gpu_kvaerno3_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_kvaerno3_perform_step.jl
@@ -95,7 +95,7 @@ end
         T
     )
 
-    dt = integ.dtnew
+    dt = integ.tdir * min(abs(integ.dtnew), abs(integ.tf - integ.t))
     t = integ.t
     p = integ.p
     tf = integ.tf
@@ -208,7 +208,7 @@ end
             integ.tprev = t
             integ.u = u
 
-            if (tf - t - dt) < convert(T, 1.0f-14)
+            if integ.tdir * (tf - t - dt) < convert(T, 1.0f-14)
                 integ.t = tf
             else
                 if integ.tstops !== nothing && integ.tstops_idx <= length(integ.tstops) &&

--- a/src/ensemblegpukernel/perform_step/gpu_kvaerno5_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_kvaerno5_perform_step.jl
@@ -126,7 +126,7 @@ end
         T
     )
 
-    dt = integ.dtnew
+    dt = integ.tdir * min(abs(integ.dtnew), abs(integ.tf - integ.t))
     t = integ.t
     p = integ.p
     tf = integ.tf
@@ -276,7 +276,7 @@ end
             integ.tprev = t
             integ.u = u
 
-            if (tf - t - dt) < convert(T, 1.0f-14)
+            if integ.tdir * (tf - t - dt) < convert(T, 1.0f-14)
                 integ.t = tf
             else
                 if integ.tstops !== nothing && integ.tstops_idx <= length(integ.tstops) &&

--- a/src/ensemblegpukernel/perform_step/gpu_rodas4_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_rodas4_perform_step.jl
@@ -122,7 +122,7 @@ end
         T
     )
 
-    dt = integ.dtnew
+    dt = integ.tdir * min(abs(integ.dtnew), abs(integ.tf - integ.t))
     t = integ.t
     p = integ.p
     tf = integ.tf
@@ -253,7 +253,7 @@ end
             integ.tprev = t
             integ.u = u
 
-            if (tf - t - dt) < convert(T, 1.0f-14)
+            if integ.tdir * (tf - t - dt) < convert(T, 1.0f-14)
                 integ.t = tf
             else
                 if integ.tstops !== nothing && integ.tstops_idx <= length(integ.tstops) &&

--- a/src/ensemblegpukernel/perform_step/gpu_rodas5P_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_rodas5P_perform_step.jl
@@ -159,7 +159,7 @@ end
         T
     )
 
-    dt = integ.dtnew
+    dt = integ.tdir * min(abs(integ.dtnew), abs(integ.tf - integ.t))
     t = integ.t
     p = integ.p
     tf = integ.tf
@@ -327,7 +327,7 @@ end
             integ.tprev = t
             integ.u = u
 
-            if (tf - t - dt) < convert(T, 1.0f-14)
+            if integ.tdir * (tf - t - dt) < convert(T, 1.0f-14)
                 integ.t = tf
             else
                 if integ.tstops !== nothing && integ.tstops_idx <= length(integ.tstops) &&

--- a/src/ensemblegpukernel/perform_step/gpu_rosenbrock23_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_rosenbrock23_perform_step.jl
@@ -77,7 +77,7 @@ end
         integ.alg,
         T
     )
-    dt = integ.dtnew
+    dt = integ.tdir * min(abs(integ.dtnew), abs(integ.tf - integ.t))
     t = integ.t
     p = integ.p
     tf = integ.tf
@@ -178,7 +178,7 @@ end
             integ.tprev = t
             integ.u = u
 
-            if (tf - t - dt) < convert(T, 1.0f-14)
+            if integ.tdir * (tf - t - dt) < convert(T, 1.0f-14)
                 integ.t = tf
             else
                 if integ.tstops !== nothing && integ.tstops_idx <= length(integ.tstops) &&

--- a/src/ensemblegpukernel/perform_step/gpu_tsit5_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_tsit5_perform_step.jl
@@ -72,7 +72,7 @@ end
         T
     )
     c1, c2, c3, c4, c5, c6 = integ.cs
-    dt = integ.dtnew
+    dt = integ.tdir * min(abs(integ.dtnew), abs(integ.tf - integ.t))
     t = integ.t
     p = integ.p
     tf = integ.tf
@@ -152,7 +152,7 @@ end
             integ.tprev = t
             integ.u = u
 
-            if (tf - t - dt) < T(1.0e-14)
+            if integ.tdir * (tf - t - dt) < T(1.0e-14)
                 integ.t = tf
             else
                 if integ.tstops !== nothing && integ.tstops_idx <= length(integ.tstops) &&

--- a/src/ensemblegpukernel/perform_step/gpu_vern7_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_vern7_perform_step.jl
@@ -82,7 +82,7 @@ end
         T
     )
 
-    dt = integ.dtnew
+    dt = integ.tdir * min(abs(integ.dtnew), abs(integ.tf - integ.t))
     t = integ.t
     p = integ.p
     tf = integ.tf
@@ -188,7 +188,7 @@ end
             integ.tprev = t
             integ.u = u
 
-            if (tf - t - dt) < convert(T, 1.0f-14)
+            if integ.tdir * (tf - t - dt) < convert(T, 1.0f-14)
                 integ.t = tf
             else
                 if integ.tstops !== nothing && integ.tstops_idx <= length(integ.tstops) &&

--- a/src/ensemblegpukernel/perform_step/gpu_vern9_perform_step.jl
+++ b/src/ensemblegpukernel/perform_step/gpu_vern9_perform_step.jl
@@ -132,7 +132,7 @@ end
         T
     )
 
-    dt = integ.dtnew
+    dt = integ.tdir * min(abs(integ.dtnew), abs(integ.tf - integ.t))
     t = integ.t
     p = integ.p
     tf = integ.tf
@@ -297,7 +297,7 @@ end
             integ.tprev = t
             integ.u = u
 
-            if (tf - t - dt) < convert(T, 1.0e-14)
+            if integ.tdir * (tf - t - dt) < convert(T, 1.0e-14)
                 integ.t = tf
             else
                 if integ.tstops !== nothing && integ.tstops_idx <= length(integ.tstops) &&

--- a/test/gpu_kernel_de/gpu_ode_regression.jl
+++ b/test/gpu_kernel_de/gpu_ode_regression.jl
@@ -153,3 +153,18 @@ end
         overshoot_sol.u[1].u[end], SVector(1.0f0); atol = 2eps(Float32), rtol = 0
     )
 end
+
+@testset "Adaptive final state after overshoot ($alg)" for alg in algs
+    unit_rate(u, p, t) = SVector(1.0f0)
+    overshoot_prob = ODEProblem{false}(unit_rate, SVector(0.0f0), (0.0f0, 0.3f0))
+    overshoot_ensemble = EnsembleProblem(overshoot_prob; safetycopy = false)
+    overshoot_sol = solve(
+        overshoot_ensemble, alg, EnsembleGPUKernel(backend);
+        trajectories = 2, adaptive = true, dt = 1.0f0, save_everystep = false
+    )
+
+    @test overshoot_sol.u[1].t == Float32[0, 0.3]
+    @test isapprox(
+        overshoot_sol.u[1].u[end], SVector(0.3f0); atol = 2eps(Float32), rtol = 0
+    )
+end

--- a/test/gpu_kernel_de/gpu_ode_regression.jl
+++ b/test/gpu_kernel_de/gpu_ode_regression.jl
@@ -164,7 +164,5 @@ end
     )
 
     @test overshoot_sol.u[1].t == Float32[0, 0.3]
-    @test isapprox(
-        overshoot_sol.u[1].u[end], SVector(0.3f0); atol = 2eps(Float32), rtol = 0
-    )
+    @test overshoot_sol.u[1].u[end] == SVector(0.3f0)
 end

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
@@ -170,3 +170,18 @@ for alg in algs
         )
     end
 end
+
+@testset "Adaptive final state after overshoot ($alg)" for alg in algs
+    unit_rate(u, p, t) = SVector(1.0f0)
+    overshoot_prob = ODEProblem{false}(unit_rate, SVector(0.0f0), (0.0f0, 0.3f0))
+    overshoot_ensemble = EnsembleProblem(overshoot_prob; safetycopy = false)
+    overshoot_sol = solve(
+        overshoot_ensemble, alg, EnsembleGPUKernel(backend, 0.0);
+        trajectories = 2, adaptive = true, dt = 1.0f0, save_everystep = false
+    )
+
+    @test overshoot_sol.u[1].t == Float32[0, 0.3]
+    @test isapprox(
+        overshoot_sol.u[1].u[end], SVector(0.3f0); atol = 2eps(Float32), rtol = 0
+    )
+end

--- a/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
+++ b/test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl
@@ -181,7 +181,12 @@ end
     )
 
     @test overshoot_sol.u[1].t == Float32[0, 0.3]
-    @test isapprox(
-        overshoot_sol.u[1].u[end], SVector(0.3f0); atol = 2eps(Float32), rtol = 0
-    )
+    if alg isa Union{GPURodas4, GPURodas5P}
+        @test isapprox(
+            overshoot_sol.u[1].u[end], SVector(0.3f0);
+            atol = 8 * eps(0.3f0), rtol = 0
+        )
+    else
+        @test overshoot_sol.u[1].u[end] == SVector(0.3f0)
+    end
 end

--- a/test/gpu_kernel_de/tsit5_accuracy.jl
+++ b/test/gpu_kernel_de/tsit5_accuracy.jl
@@ -33,3 +33,18 @@ end
     @test all(s -> s.t[end] == T(0.1), sol.u)
     @test all(s -> isapprox(s.u[end], exact; atol = T(2.0e-6), rtol = T(2.0e-6)), sol.u)
 end
+
+@testset "Tsit5 overshoot ($alg, $T)" for
+    T in (GROUP in ("CPU", "CUDA", "AMDGPU") ? (Float32, Float64) : (Float32,)),
+        alg in (GPUTsit5(), GPUTsit5IController())
+    rhs(u, p, t) = SVector(-u[1], -100 * u[2])
+    prob = ODEProblem{false}(rhs, SVector(one(T), one(T)), (zero(T), T(0.01)))
+    sol = solve(
+        EnsembleProblem(prob), alg, EnsembleGPUKernel(backend, 0.0);
+        trajectories = 2, adaptive = true, dt = T(0.1),
+        abstol = T(1.0e-5), reltol = T(1.0e-2), save_everystep = false
+    )
+    exact = SVector(exp(-T(0.01)), exp(-T(1)))
+    @test all(s -> s.t[end] == T(0.01), sol.u)
+    @test all(s -> isapprox(s.u[end], exact; rtol = T(1.0e-2)), sol.u)
+end


### PR DESCRIPTION
Fixes #535.

Adaptive `step!` took `dt = integ.dtnew` without limiting it to remaining time, then treated `tf - t - dt < 1e-14` as done and set `t = tf` while keeping the oversized RK state. The remaining-time clamp on `dtnew` only affects the next proposal, so the first accepted step can still overshoot `tspan[2]`.

Limit the current `dt` to remaining time before stages, with `tdir`:

```julia
dt = integ.tdir * min(abs(integ.dtnew), abs(integ.tf - integ.t))
```

in GPUTsit5, GPUVern7/9, GPURosenbrock23, GPURodas4/5P, and GPUKvaerno3/5. PI/I controller parameters are unchanged.

## Tests

`GROUP=CPU julia +1.10 --project=test`:

- `test/gpu_kernel_de/tsit5_accuracy.jl`
- `test/gpu_kernel_de/tsit5_i_controller.jl`
- `test/gpu_kernel_de/gpu_ode_regression.jl`
- `test/gpu_kernel_de/stiff_ode/gpu_ode_regression.jl`

293 passed. Runic `--check --diff` on the touched files passed.

The #535 public probe (`tspan = (0, 0.01)`, `dt = 0.1`, `reltol = 1e-2`) now accepts `dt = 0.01` and matches `exp.(-[1, 100] * 0.01)` to the requested tolerance.

CUDA/GPU and full `Pkg.test` were not run (no NVIDIA GPU).