### PR TITLE
Release DiffEqGPU 3.21.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqGPU"
 uuid = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 authors = ["Chris Rackauckas", "SciML"]
-version = "3.21.0"
+version = "3.21.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Bumps `DiffEqGPU` 3.21.0 -> 3.21.1 (patch).

Source files changed since 3.21.0:
- `src/ensemblegpukernel/callbacks.jl`
- `src/ensemblegpukernel/lowerlevel_solve.jl`
- `src/ensemblegpukernel/perform_step/gpu_kvaerno3_perform_step.jl`
- `src/ensemblegpukernel/perform_step/gpu_kvaerno5_perform_step.jl`
- `src/ensemblegpukernel/perform_step/gpu_rodas4_perform_step.jl`
- `src/ensemblegpukernel/perform_step/gpu_rodas5P_perform_step.jl`
- `src/ensemblegpukernel/perform_step/gpu_rosenbrock23_perform_step.jl`
- `src/ensemblegpukernel/perform_step/gpu_tsit5_perform_step.jl`
- `src/ensemblegpukernel/perform_step/gpu_vern7_perform_step.jl`
- `src/ensemblegpukernel/perform_step/gpu_vern9_perform_step.jl`
- `src/solve.jl`

Commits:
- Add AirspeedVelocity benchmarking CI (#536)
- Fix JET-reported defects surfaced on Julia 1.13 (#538)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
